### PR TITLE
Gives the Editor’s View Controller `Appearance`’s `tintColor`

### DIFF
--- a/PinpointKit/PinpointKit/Sources/FeedbackViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/FeedbackViewController.swift
@@ -106,6 +106,7 @@ public final class FeedbackViewController: UITableViewController {
         header.viewModel = ScreenshotHeaderView.ViewModel(screenshot: screenshotToDisplay, hintText: interfaceCustomization?.interfaceText.feedbackEditHint)
         header.screenshotButtonTapHandler = { [weak self] button in
             let editImageViewController = NavigationController(rootViewController: editor.viewController)
+            editImageViewController.view.tintColor = self?.interfaceCustomization?.appearance.tintColor
             self?.presentViewController(editImageViewController, animated: true, completion: nil)
         }
         


### PR DESCRIPTION
Was there a particular reason the editor used the default blue `tintColor`? It seems like, at least according to the docs for `InterfaceCustomization.Appearance`'s `tintColor` property, we'd want this to carry through to the editor.

``` swift
/// The tint color of PinpointKit views used to style interactive and selected elements.
let tintColor: UIColor?
```

This PR gives the editor's VC’s view the `tintColor`.

![simulator screen shot may 27 2016 5 25 04 pm](https://cloud.githubusercontent.com/assets/7883805/15621631/2e9d4a4e-2430-11e6-9a7c-f387d04e0fa5.png)![simulator screen shot may 27 2016 5 25 00 pm](https://cloud.githubusercontent.com/assets/7883805/15621630/2e554dca-2430-11e6-84a7-725de101fb1c.png)
