### PR TITLE
Use the Compact Lazy Syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,7 @@ PinpointKit.defaultPinpointKit.show(fromViewController: viewController)
 If you want to have the feedback view display from a shake gesture, simply do the following in your [`UIApplicationDelegate`](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIApplicationDelegate_Protocol/index.html) class:
 
 ```swift
-lazy var window: UIWindow? = {
-    return ShakeDetectingWindow(frame: UIScreen.mainScreen().bounds)
-}()
+lazy var window: UIWindow? = return ShakeDetectingWindow(frame: UIScreen.mainScreen().bounds)
 ```
 
 If you don't want to use [`defaultPinpointKit`](https://github.com/Lickability/PinpointKit/blob/master/PinpointKit/PinpointKit/Sources/PinpointKit.swift#L17) you can specify both a [`Configuration`](https://github.com/Lickability/PinpointKit/blob/master/PinpointKit/PinpointKit/Sources/Configuration.swift) and [`PinpointKitDelegate`](https://github.com/Lickability/PinpointKit/blob/master/PinpointKit/PinpointKit/Sources/PinpointKit.swift#L49) instances on initialization of [`PinpointKit`](https://github.com/Lickability/PinpointKit/blob/master/PinpointKit/PinpointKit/Sources/PinpointKit.swift).


### PR DESCRIPTION
It's just nicer.
