### PR TITLE
Makes AnnotationView a protocol

### DIFF
--- a/PinpointKit/PinpointKit/Sources/AnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/AnnotationView.swift
@@ -8,18 +8,16 @@
 
 import UIKit
 
+/// The alpha value used for annotation borders.
+let BorderAlpha: CGFloat = 0.7
+
 /// The base annotation `UIView` subclass.
-public class AnnotationView: UIView {
-    
-    /// The alpha value used for annotation borders.
-    static let BorderAlpha: CGFloat = 0.7
+public protocol AnnotationView {
     
     // MARK: - Properties
     
     /// The frame of the annotation view.
-    var annotationFrame: CGRect? {
-        return nil
-    }
+    var annotationFrame: CGRect? { get }
     
     // MARK: - Helpers
     
@@ -28,25 +26,27 @@ public class AnnotationView: UIView {
      
      - parameter translation: The amount to translate the control points.
      */
-    func moveControlPoints(translation: CGPoint) {
-        
-    }
+    func moveControlPoints(translation: CGPoint)
     
     /**
      Scales the control points of the annotation by the amount specified in `scale`.
      
      - parameter scale: The factor by which to scale the annotation.
      */
-    func scaleControlPoints(scale: CGFloat) {
-        
-    }
+    func scaleControlPoints(scale: CGFloat)
     
     /**
      Sets the second control point of the annotation to `point`.
      
      - parameter point: The new value for the annotation’s second control point.
      */
-    func setSecondControlPoint(point: CGPoint) {
-        
+    func setSecondControlPoint(point: CGPoint)
+    
+    func view() -> UIView
+}
+
+extension AnnotationView where Self: UIView {
+    public func view() -> UIView {
+        return self
     }
 }

--- a/PinpointKit/PinpointKit/Sources/AnnotationsView.swift
+++ b/PinpointKit/PinpointKit/Sources/AnnotationsView.swift
@@ -39,13 +39,13 @@ class AnnotationsView: UIView {
     func moveBlurViewAboveBlurViewsAndUnderOthers(blurView blurView: BlurAnnotationView) {
         var lastBlurViewIndex: Int?
         for (index, subview) in subviews.enumerate() {
-            if subview is BlurAnnotationView && subview as? BlurAnnotationView != blurView {
+            if let subview = subview as? BlurAnnotationView {
                 lastBlurViewIndex = index
             }
         }
         
         let index = lastBlurViewIndex?.successor() ?? 0
-        insertSubview(blurView, atIndex: index)
+        insertSubview(blurView.view(), atIndex: index)
     }
     
     override func tintColorDidChange() {

--- a/PinpointKit/PinpointKit/Sources/ArrowAnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/ArrowAnnotationView.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// The default arrow annotation view.
-public class ArrowAnnotationView: AnnotationView {
+public class ArrowAnnotationView: UIView, AnnotationView {
 
     // MARK: - Properties
 
@@ -21,15 +21,11 @@ public class ArrowAnnotationView: AnnotationView {
         }
     }
 
-    override var annotationFrame: CGRect? {
+    public var annotationFrame: CGRect? {
         return annotation?.path?.bounds
     }
 
     // MARK: - Initializers
-
-    convenience init() {
-        self.init(frame: CGRect.zero)
-    }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -68,16 +64,15 @@ public class ArrowAnnotationView: AnnotationView {
         return annotation?.touchTargetPath?.containsPoint(point) ?? false
     }
 
-
     // MARK: - AnnotationView
 
-    override func setSecondControlPoint(point: CGPoint) {
+    public func setSecondControlPoint(point: CGPoint) {
         guard let previousAnnotation = annotation else { return }
         
         annotation = ArrowAnnotation(startLocation: previousAnnotation.startLocation, endLocation: point, strokeColor: previousAnnotation.strokeColor)
     }
 
-    override func moveControlPoints(translation: CGPoint) {
+    public func moveControlPoints(translation: CGPoint) {
         guard let previousAnnotation = annotation else { return }
         let startLocation = CGPoint(x: previousAnnotation.startLocation.x + translation.x, y: previousAnnotation.startLocation.y + translation.y)
         let endLocation = CGPoint(x: previousAnnotation.endLocation.x + translation.x, y: previousAnnotation.endLocation.y + translation.y)
@@ -85,7 +80,7 @@ public class ArrowAnnotationView: AnnotationView {
         annotation = ArrowAnnotation(startLocation: startLocation, endLocation: endLocation, strokeColor: previousAnnotation.strokeColor)
     }
     
-    override func scaleControlPoints(scale: CGFloat) {
+    public func scaleControlPoints(scale: CGFloat) {
         guard let previousAnnotation = annotation else { return }
         let startLocation = previousAnnotation.scaledPoint(previousAnnotation.startLocation, scale: scale)
         let endLocation = previousAnnotation.scaledPoint(previousAnnotation.endLocation, scale: scale)

--- a/PinpointKit/PinpointKit/Sources/ArrowAnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/ArrowAnnotationView.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// The default arrow annotation view.
-public class ArrowAnnotationView: UIView, AnnotationView {
+public final class ArrowAnnotationView: UIView, AnnotationView {
 
     // MARK: - Properties
 

--- a/PinpointKit/PinpointKit/Sources/BlurAnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/BlurAnnotationView.swift
@@ -11,7 +11,7 @@ import GLKit
 import CoreImage
 
 /// The default blur annotation view.
-public class BlurAnnotationView: AnnotationView, GLKViewDelegate {
+public class BlurAnnotationView: UIView, AnnotationView, GLKViewDelegate {
 
     // MARK: - Properties
 
@@ -42,7 +42,7 @@ public class BlurAnnotationView: AnnotationView, GLKViewDelegate {
         }
     }
     
-    override var annotationFrame: CGRect? {
+    public var annotationFrame: CGRect? {
         return annotation?.frame
     }
     
@@ -102,7 +102,7 @@ public class BlurAnnotationView: AnnotationView, GLKViewDelegate {
         
         if drawsBorder {
             let context = UIGraphicsGetCurrentContext()
-            tintColor?.colorWithAlphaComponent(self.dynamicType.BorderAlpha).setStroke()
+            tintColor?.colorWithAlphaComponent(BorderAlpha).setStroke()
             
             // Since this draws under the GLKView, and strokes extend both inside and outside, we have to double the intended width.
             let strokeWidth: CGFloat = 1.0
@@ -115,13 +115,13 @@ public class BlurAnnotationView: AnnotationView, GLKViewDelegate {
         
     // MARK: - AnnotationView
 
-    override func setSecondControlPoint(point: CGPoint) {
+    public func setSecondControlPoint(point: CGPoint) {
         guard let previousAnnotation = annotation else { return }
         
         annotation = BlurAnnotation(startLocation: previousAnnotation.startLocation, endLocation: point, image: previousAnnotation.image)
     }
 
-    override func moveControlPoints(translation: CGPoint) {
+    public func moveControlPoints(translation: CGPoint) {
         guard let previousAnnotation = annotation else { return }
         let startLocation = CGPoint(x: previousAnnotation.startLocation.x + translation.x, y: previousAnnotation.startLocation.y + translation.y)
         let endLocation = CGPoint(x: previousAnnotation.endLocation.x + translation.x, y: previousAnnotation.endLocation.y + translation.y)
@@ -129,7 +129,7 @@ public class BlurAnnotationView: AnnotationView, GLKViewDelegate {
         annotation = BlurAnnotation(startLocation: startLocation, endLocation: endLocation, image: previousAnnotation.image)
     }
 
-    override func scaleControlPoints(scale: CGFloat) {
+    public func scaleControlPoints(scale: CGFloat) {
         guard let previousAnnotation = annotation else { return }
         let startLocation = previousAnnotation.scaledPoint(previousAnnotation.startLocation, scale: scale)
         let endLocation = previousAnnotation.scaledPoint(previousAnnotation.endLocation, scale: scale)

--- a/PinpointKit/PinpointKit/Sources/BlurAnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/BlurAnnotationView.swift
@@ -11,7 +11,7 @@ import GLKit
 import CoreImage
 
 /// The default blur annotation view.
-public class BlurAnnotationView: UIView, AnnotationView, GLKViewDelegate {
+public final class BlurAnnotationView: UIView, AnnotationView, GLKViewDelegate {
 
     // MARK: - Properties
 

--- a/PinpointKit/PinpointKit/Sources/BoxAnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/BoxAnnotationView.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// The default box annotation view.
-public class BoxAnnotationView: AnnotationView {
+public final class BoxAnnotationView: UIView, AnnotationView {
 
     // MARK: - Properties
     
@@ -21,7 +21,7 @@ public class BoxAnnotationView: AnnotationView {
         }
     }
 
-    override var annotationFrame: CGRect? {
+    public var annotationFrame: CGRect? {
         return annotation?.frame
     }
 
@@ -72,13 +72,13 @@ public class BoxAnnotationView: AnnotationView {
 
     // MARK: - AnnotationView
 
-    override func setSecondControlPoint(point: CGPoint) {
+    public func setSecondControlPoint(point: CGPoint) {
         guard let previousAnnotation = annotation else { return }
 
         annotation = BoxAnnotation(startLocation: previousAnnotation.startLocation, endLocation: point, strokeColor: previousAnnotation.strokeColor)
     }
 
-    override func moveControlPoints(translation: CGPoint) {
+    public func moveControlPoints(translation: CGPoint) {
         guard let previousAnnotation = annotation else { return }
         let startLocation = CGPoint(x: previousAnnotation.startLocation.x + translation.x, y: previousAnnotation.startLocation.y + translation.y)
         let endLocation = CGPoint(x: previousAnnotation.endLocation.x + translation.x, y: previousAnnotation.endLocation.y + translation.y)
@@ -86,7 +86,7 @@ public class BoxAnnotationView: AnnotationView {
         annotation = BoxAnnotation(startLocation: startLocation, endLocation: endLocation, strokeColor: previousAnnotation.strokeColor)
     }
     
-    override func scaleControlPoints(scale: CGFloat) {
+    public func scaleControlPoints(scale: CGFloat) {
         guard let previousAnnotation = annotation else { return }
         let startLocation = previousAnnotation.scaledPoint(previousAnnotation.startLocation, scale: scale)
         let endLocation = previousAnnotation.scaledPoint(previousAnnotation.endLocation, scale: scale)

--- a/PinpointKit/PinpointKit/Sources/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Editing/EditImageViewController.swift
@@ -335,14 +335,14 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
             let annotationViewIsNotBlurView = !(possibleAnnotationView is BlurAnnotationView)
             
             if let annotationView = possibleAnnotationView {
-                annotationsView.bringSubviewToFront(annotationView)
+                annotationsView.bringSubviewToFront(annotationView.view())
                 
                 if annotationViewIsNotBlurView {
                     navigationController?.barHideOnTapGestureRecognizer.failRecognizing()
                 }
             }
             
-            if possibleAnnotationView != currentTextAnnotationView {
+            if possibleAnnotationView?.view() != currentTextAnnotationView?.view() {
                 endEditingTextView()
                 
                 if !(possibleAnnotationView is TextAnnotationView) {
@@ -372,10 +372,13 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
                 }
             }
             
-            let annotationView = annotationViews.first
-            let annotationViewsFiltered = annotationViews.filter { $0 == annotationViews.first }
+            if let annotationView = annotationViews.first {
+                let annotationViewsFiltered = annotationViews.filter { $0.view() == annotationView.view() }
+                
+                return annotationViewsFiltered.count == numberOfTouches ? annotationView : nil
+            }
             
-            return annotationViewsFiltered.count == numberOfTouches ? annotationView : nil
+            return  nil
         }
         
         return annotationViewInView(view, withLocation: gestureRecognizer.locationInView(view))
@@ -480,12 +483,13 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         
         let factory = AnnotationViewFactory(image: imageView.image?.CGImage, currentLocation: currentLocation, tool: currentTool, strokeColor: annotationStrokeColor)
         
-        let view: AnnotationView = factory.annotationView()
+        let annotationView = factory.annotationView()
+        let view = annotationView.view()
         
         view.frame = annotationsView.bounds
         view.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
         annotationsView.addSubview(view)
-        currentAnnotationView = view
+        currentAnnotationView = annotationView
         beginEditingTextView()
     }
     
@@ -571,7 +575,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
     
     @objc private func handleDoubleTapGestureRecognizer(gestureRecognizer: UITapGestureRecognizer) {
         if let view = annotationViewWithGestureRecognizer(gestureRecognizer) {
-            deleteAnnotationView(view, animated: true)
+            deleteAnnotationView(view.view(), animated: true)
         }
     }
     
@@ -580,16 +584,16 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
             return
         }
         
-        guard let view = annotationViewWithGestureRecognizer(gestureRecognizer) else { return }
+        guard let annotationView = annotationViewWithGestureRecognizer(gestureRecognizer) else { return }
         
-        selectedAnnotationView = view
+        selectedAnnotationView = annotationView
         becomeFirstResponder()
         
         let point = gestureRecognizer.locationInView(gestureRecognizer.view)
         let targetRect = CGRect(origin: point, size: CGSize())
         
         let controller = UIMenuController.sharedMenuController()
-        controller.setTargetRect(targetRect, inView: view)
+        controller.setTargetRect(targetRect, inView: annotationView.view())
         controller.menuItems = [
             UIMenuItem(title: "Delete", action: #selector(EditImageViewController.deleteSelectedAnnotationView))
         ]
@@ -615,7 +619,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
     
     @objc private func deleteSelectedAnnotationView() {
         if let selectedAnnotationView = selectedAnnotationView {
-            deleteAnnotationView(selectedAnnotationView, animated: true)
+            deleteAnnotationView(selectedAnnotationView.view(), animated: true)
         }
     }
     

--- a/PinpointKit/PinpointKit/Sources/TextAnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/TextAnnotationView.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// The default text annotation view.
-public class TextAnnotationView: UIView, AnnotationView, UITextViewDelegate {
+public final class TextAnnotationView: UIView, AnnotationView, UITextViewDelegate {
     private static let TextViewInset = UIEdgeInsets(top: 8, left: 0, bottom: 8, right: 0)
     private static let TextViewLineFragmentPadding: CGFloat = 5.0
     

--- a/PinpointKit/PinpointKit/Sources/TextAnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/TextAnnotationView.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// The default text annotation view.
-public class TextAnnotationView: AnnotationView, UITextViewDelegate {
+public class TextAnnotationView: UIView, AnnotationView, UITextViewDelegate {
     private static let TextViewInset = UIEdgeInsets(top: 8, left: 0, bottom: 8, right: 0)
     private static let TextViewLineFragmentPadding: CGFloat = 5.0
     
@@ -36,7 +36,7 @@ public class TextAnnotationView: AnnotationView, UITextViewDelegate {
         return textView
     }()
     
-    override var annotationFrame: CGRect? {
+    public var annotationFrame: CGRect? {
         return textView.frame
     }
     
@@ -48,6 +48,14 @@ public class TextAnnotationView: AnnotationView, UITextViewDelegate {
             originalTextViewFrame = textView.frame
             (textView.layoutManager as? StrokeLayoutManager)?.strokeColor = annotation?.strokeColor
         }
+    }
+    
+    public func scaleControlPoints(scale: CGFloat) {
+        
+    }
+    
+    public func setSecondControlPoint(point: CGPoint) {
+        
     }
     
     override init(frame: CGRect) {
@@ -80,7 +88,7 @@ public class TextAnnotationView: AnnotationView, UITextViewDelegate {
         
     // MARK: - AnnotationView
     
-    override func moveControlPoints(translation: CGPoint) {
+    public func moveControlPoints(translation: CGPoint) {
         textView.frame = {
             var textViewFrame = self.textView.frame
             textViewFrame.origin = CGPoint(x: textViewFrame.minX + translation.x, y: textViewFrame.minY + translation.y)
@@ -162,7 +170,7 @@ public class TextAnnotationView: AnnotationView, UITextViewDelegate {
     public func textViewDidBeginEditing(textView: UITextView) {
         textView.backgroundColor = UIColor(white: 1.0, alpha: 0.3)
         textView.layer.borderWidth = 1
-        textView.layer.borderColor = tintColor.colorWithAlphaComponent(self.dynamicType.BorderAlpha).CGColor
+        textView.layer.borderColor = tintColor.colorWithAlphaComponent(BorderAlpha).CGColor
     }
     
     public func textViewDidEndEditing(textView: UITextView) {


### PR DESCRIPTION
There didnt seem to be a great reason that this was an abstract base class, and leaves possibility for things to break without warning (or a new annotation to be implemented wrong, or based on some private behavior)

This also lets use make the current annotations `final` 

WIP-ish, relatively rough, etc
