### PR TITLE
Fixed README bug in window setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ PinpointKit uses a protocol-oriented architecture which allows almost everything
 
 * Implement a `JIRASender` that conforms to [`Sender`](https://github.com/Lickability/PinpointKit/blob/master/PinpointKit/PinpointKit/Sources/Sender.swift), allowing users to send feedback directly into your bug tracker.
 * Supply your own console log collector that aggregates messages from your third-party logging framework of choice by conforming to [`LogCollector`](https://github.com/Lickability/PinpointKit/blob/master/PinpointKit/PinpointKit/Sources/LogCollector.swift)
-* Change how lougs are viewed by creating your own view controller conforming to [`LogViewer`](https://github.com/Lickability/PinpointKit/blob/master/PinpointKit/PinpointKit/Sources/LogViewer.swift).
+* Change how logs are viewed by creating your own view controller conforming to [`LogViewer`](https://github.com/Lickability/PinpointKit/blob/master/PinpointKit/PinpointKit/Sources/LogViewer.swift).
 
 For more information on what you can customize, take a peek the documentation of [`Configuration`](https://github.com/Lickability/PinpointKit/blob/master/PinpointKit/PinpointKit/Sources/Configuration.swift).
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ PinpointKit.defaultPinpointKit.show(fromViewController: viewController)
 If you want to have the feedback view display from a shake gesture, simply do the following in your [`UIApplicationDelegate`](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIApplicationDelegate_Protocol/index.html) class:
 
 ```swift
-lazy var window: UIWindow? = return ShakeDetectingWindow(frame: UIScreen.mainScreen().bounds)
+lazy var window: UIWindow? = ShakeDetectingWindow(frame: UIScreen.mainScreen().bounds)
 ```
 
 If you don't want to use `defaultPinpointKit` you can specify both [`Configuration`](https://github.com/Lickability/PinpointKit/blob/master/PinpointKit/PinpointKit/Sources/Configuration.swift) and [`PinpointKitDelegate`](https://github.com/Lickability/PinpointKit/blob/master/PinpointKit/PinpointKit/Sources/PinpointKit.swift) instances on initialization of [`PinpointKit`](https://github.com/Lickability/PinpointKit/blob/master/PinpointKit/PinpointKit/Sources/PinpointKit.swift).
@@ -145,7 +145,7 @@ PinpointKit uses a protocol-oriented architecture which allows almost everything
 
 * Implement a `JIRASender` that conforms to [`Sender`](https://github.com/Lickability/PinpointKit/blob/master/PinpointKit/PinpointKit/Sources/Sender.swift), allowing users to send feedback directly into your bug tracker.
 * Supply your own console log collector that aggregates messages from your third-party logging framework of choice by conforming to [`LogCollector`](https://github.com/Lickability/PinpointKit/blob/master/PinpointKit/PinpointKit/Sources/LogCollector.swift)
-* Change how logs are viewed by creating your own view controller conforming to [`LogViewer`](https://github.com/Lickability/PinpointKit/blob/master/PinpointKit/PinpointKit/Sources/LogViewer.swift).
+* Change how lougs are viewed by creating your own view controller conforming to [`LogViewer`](https://github.com/Lickability/PinpointKit/blob/master/PinpointKit/PinpointKit/Sources/LogViewer.swift).
 
 For more information on what you can customize, take a peek the documentation of [`Configuration`](https://github.com/Lickability/PinpointKit/blob/master/PinpointKit/PinpointKit/Sources/Configuration.swift).
 


### PR DESCRIPTION
## What it Does

Addresses [Twitter feedback](https://twitter.com/HarshilShah1910/status/742022901231063041) from @harshilshah that pointed out a bug in our README’s implementation of the window setup.

## How to Test

1. Read the change.
2. Test that the new code compiles in a sample project.

## Notes

This regressed in da010e165645c9c53240bdc06d5702b1f53f93f5.
