### PR TITLE
Swift 2.3 Beta 1 Migration

### DIFF
--- a/Example/PinpointKitExample.xcodeproj/project.pbxproj
+++ b/Example/PinpointKitExample.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 				TargetAttributes = {
 					DA19C3E31C67D4420016861F = {
 						CreatedOnToolsVersion = 7.2.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -346,6 +347,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.Lickability.PinpointKitExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -358,6 +360,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.Lickability.PinpointKitExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -469,6 +469,11 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
 				LastUpgradeCheck = 0700;
+				TargetAttributes = {
+					4F716289CD7F1AD9C3B3FCE873010171 = {
+						LastSwiftMigration = 0800;
+					};
+				};
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -639,6 +644,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -710,6 +716,7 @@
 				PRODUCT_NAME = PinpointKit;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/PinpointKit.podspec.json
+++ b/PinpointKit.podspec.json
@@ -1,6 +1,7 @@
 {
   "name": "PinpointKit",
   "version": "0.9",
+  "homepage": "https://github.com/Lickability/PinpointKit",
   "source": {
       "git": "https://github.com/Lickability/PinpointKit.git",
       "tag": "0.9"

--- a/PinpointKit/PinpointKit.xcodeproj/project.pbxproj
+++ b/PinpointKit/PinpointKit.xcodeproj/project.pbxproj
@@ -413,9 +413,11 @@
 				TargetAttributes = {
 					DA0DA6011C53049B0012ADBE = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 					DA0DA60B1C53049B0012ADBE = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -641,6 +643,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -659,6 +662,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = net.Lickability.PinpointKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -669,6 +673,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.Lickability.PinpointKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -679,6 +684,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.Lickability.PinpointKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};

--- a/PinpointKit/PinpointKit/Sources/BlurAnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/BlurAnnotationView.swift
@@ -101,7 +101,8 @@ public class BlurAnnotationView: AnnotationView, GLKViewDelegate {
         super.drawRect(rect)
         
         if drawsBorder {
-            let context = UIGraphicsGetCurrentContext()
+            guard let context = UIGraphicsGetCurrentContext() else { assertionFailure(); return }
+            
             tintColor?.colorWithAlphaComponent(self.dynamicType.BorderAlpha).setStroke()
             
             // Since this draws under the GLKView, and strokes extend both inside and outside, we have to double the intended width.

--- a/PinpointKit/PinpointKit/Sources/MailSender.swift
+++ b/PinpointKit/PinpointKit/Sources/MailSender.swift
@@ -158,16 +158,14 @@ extension MailSender: MFMailComposeViewControllerDelegate {
     
     private func completeWithResult(result: MFMailComposeResult, error: NSError?) {
         switch result {
-        case MFMailComposeResultCancelled:
+        case .Cancelled:
             fail(.MailCanceled(underlyingError: error))
-        case MFMailComposeResultFailed:
+        case .Failed:
             fail(.MailFailed(underlyingError: error))
-        case MFMailComposeResultSaved:
+        case .Saved:
             succeed(.Saved)
-        case MFMailComposeResultSent:
+        case .Sent:
             succeed(.Sent)
-        default:
-            fail(.Unknown)
         }
     }
 }

--- a/PinpointKit/PinpointKit/Sources/Screenshotter.swift
+++ b/PinpointKit/PinpointKit/Sources/Screenshotter.swift
@@ -28,7 +28,10 @@ public class Screenshotter {
             window.drawViewHierarchyInRect(window.bounds, afterScreenUpdates: false)
         }
         
-        let image = UIGraphicsGetImageFromCurrentImageContext()
+        guard let image = UIGraphicsGetImageFromCurrentImageContext() else {
+            preconditionFailure("`UIGraphicsGetImageFromCurrentImageContext()` should never return `nil` as we satisify the requirements of having a bitmap-based current context created with `UIGraphicsBeginImageContextWithOptions(_:_:_:)`")
+        }
+        
         UIGraphicsEndImageContext()
         
         return image

--- a/PinpointKit/PinpointKit/Sources/StrokeLayoutManager.swift
+++ b/PinpointKit/PinpointKit/Sources/StrokeLayoutManager.swift
@@ -18,7 +18,7 @@ final class StrokeLayoutManager: NSLayoutManager {
     var strokeWidth: CGFloat?
     
     override func drawGlyphsForGlyphRange(glyphsToShow: NSRange, atPoint origin: CGPoint) {
-        let context = UIGraphicsGetCurrentContext()
+        guard let context = UIGraphicsGetCurrentContext() else { assertionFailure(); return }
         
         let firstIndex = characterIndexForGlyphAtIndex(glyphsToShow.location)
         let attributes = textStorage?.attributesAtIndex(firstIndex, effectiveRange: nil)

--- a/PinpointKit/PinpointKit/Sources/UIView+PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/UIView+PinpointKit.swift
@@ -13,8 +13,13 @@ extension UIView {
     var pinpoint_screenshot: UIImage {
         UIGraphicsBeginImageContextWithOptions(bounds.size, true, 0)
         drawViewHierarchyInRect(bounds, afterScreenUpdates: true)
-        let image = UIGraphicsGetImageFromCurrentImageContext()
+        
+        guard let image = UIGraphicsGetImageFromCurrentImageContext() else {
+            preconditionFailure("`UIGraphicsGetImageFromCurrentImageContext()` should never return `nil` as we satisify the requirements of having a bitmap-based current context created with `UIGraphicsBeginImageContextWithOptions(_:_:_:)`")
+        }
+        
         UIGraphicsEndImageContext()
+        
         return image
     }
 }


### PR DESCRIPTION
📝 This is pointing at the new `swift-2.3` branch, not `develop`.

- Runs the migrator in Xcode 8 to update to Swift 2.3 syntax. No syntax changes were performed by the migrator.
- Fixes leftover errors. Follow the commit messages and PR comments for descriptions of changes.