### PR TITLE
Swift 3.0 Beta 1 Migration

### DIFF
--- a/Example/PinpointKitExample.xcodeproj/project.pbxproj
+++ b/Example/PinpointKitExample.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 				TargetAttributes = {
 					DA19C3E31C67D4420016861F = {
 						CreatedOnToolsVersion = 7.2.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -346,6 +347,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.Lickability.PinpointKitExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -358,6 +360,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.Lickability.PinpointKitExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Example/PinpointKitExample/AppDelegate.swift
+++ b/Example/PinpointKitExample/AppDelegate.swift
@@ -12,9 +12,9 @@ import PinpointKit
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    lazy var window: UIWindow? = ShakeDetectingWindow(frame: UIScreen.mainScreen().bounds)
+    lazy var window: UIWindow? = ShakeDetectingWindow(frame: UIScreen.main().bounds)
     
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         NSLog("Initial test log for the system logger.")
         return true
     }

--- a/Example/PinpointKitExample/AppDelegate.swift
+++ b/Example/PinpointKitExample/AppDelegate.swift
@@ -12,7 +12,7 @@ import PinpointKit
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    lazy var window: UIWindow? = ShakeDetectingWindow(frame: UIScreen.main().bounds)
+    var window: UIWindow? = ShakeDetectingWindow(frame: UIScreen.main().bounds)
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         NSLog("Initial test log for the system logger.")

--- a/Example/PinpointKitExample/ViewController.swift
+++ b/Example/PinpointKitExample/ViewController.swift
@@ -18,7 +18,7 @@ final class ViewController: UITableViewController {
         tableView.tableFooterView = UIView()
     }
     
-    override func viewDidAppear(animated: Bool) {
+    override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
         PinpointKit.defaultPinpointKit.show(fromViewController: self)

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -469,6 +469,11 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
 				LastUpgradeCheck = 0700;
+				TargetAttributes = {
+					4F716289CD7F1AD9C3B3FCE873010171 = {
+						LastSwiftMigration = 0800;
+					};
+				};
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -639,6 +644,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -710,6 +716,7 @@
 				PRODUCT_NAME = PinpointKit;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/PinpointKit/PinpointKit.xcodeproj/project.pbxproj
+++ b/PinpointKit/PinpointKit.xcodeproj/project.pbxproj
@@ -413,9 +413,11 @@
 				TargetAttributes = {
 					DA0DA6011C53049B0012ADBE = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 					DA0DA60B1C53049B0012ADBE = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -641,6 +643,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -659,6 +662,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = net.Lickability.PinpointKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -669,6 +673,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.Lickability.PinpointKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -679,6 +684,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.Lickability.PinpointKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/PinpointKit/PinpointKit/Sources/AnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/AnnotationView.swift
@@ -28,7 +28,7 @@ public class AnnotationView: UIView {
      
      - parameter translation: The amount to translate the control points.
      */
-    func moveControlPoints(translation: CGPoint) {
+    func moveControlPoints(_ translation: CGPoint) {
         
     }
     
@@ -37,7 +37,7 @@ public class AnnotationView: UIView {
      
      - parameter scale: The factor by which to scale the annotation.
      */
-    func scaleControlPoints(scale: CGFloat) {
+    func scaleControlPoints(_ scale: CGFloat) {
         
     }
     
@@ -46,7 +46,7 @@ public class AnnotationView: UIView {
      
      - parameter point: The new value for the annotation’s second control point.
      */
-    func setSecondControlPoint(point: CGPoint) {
+    func setSecondControlPoint(_ point: CGPoint) {
         
     }
 }

--- a/PinpointKit/PinpointKit/Sources/Annotations.swift
+++ b/PinpointKit/PinpointKit/Sources/Annotations.swift
@@ -46,8 +46,8 @@ class Annotation {
      
      - returns: The scaled point.
      */
-    func scaledPoint(point: CGPoint, scale: CGFloat) -> CGPoint {
-        var scaledRect = CGRectApplyAffineTransform(frame, CGAffineTransformMakeScale(scale, scale))
+    func scaledPoint(_ point: CGPoint, scale: CGFloat) -> CGPoint {
+        var scaledRect = frame.apply(transform: CGAffineTransform(scaleX: scale, y: scale))
         
         let centeredXDistance = scaledRect.width / 2.0 - frame.width / 2.0
         let centeredYDistance = scaledRect.height / 2.0 - frame.height / 2.0
@@ -160,25 +160,25 @@ class BlurAnnotation: Annotation {
         var image: CIImage? = self.image
         let extent = image?.extent
 
-        let transform = NSValue(CGAffineTransform: CGAffineTransformIdentity)
+        let transform = NSValue(cgAffineTransform: CGAffineTransform.identity)
         let affineClampFilter = CIFilter(name: "CIAffineClamp")
         affineClampFilter?.setValue(image, forKey: kCIInputImageKey)
         affineClampFilter?.setValue(transform, forKey: kCIInputTransformKey)
-        image = affineClampFilter?.valueForKey(kCIOutputImageKey) as? CIImage
+        image = affineClampFilter?.value(forKey: kCIOutputImageKey) as? CIImage
 
         let pixellateFilter = CIFilter(name: "CIPixellate")
         pixellateFilter?.setValue(image, forKey: kCIInputImageKey)
         
         let inputScale = 16
         pixellateFilter?.setValue(inputScale, forKey: kCIInputScaleKey)
-        image = pixellateFilter?.valueForKey(kCIOutputImageKey) as? CIImage
+        image = pixellateFilter?.value(forKey: kCIOutputImageKey) as? CIImage
 
         if let imageValue = image, extentValue = extent {
-            let vector = CIVector(CGRect: extentValue)
+            let vector = CIVector(cgRect: extentValue)
             let filter: CIFilter? = CIFilter(name: "CICrop")
             filter?.setValue(imageValue, forKey: kCIInputImageKey)
             filter?.setValue(vector, forKey: "inputRectangle")
-            image = filter?.valueForKey(kCIOutputImageKey) as? CIImage
+            image = filter?.value(forKey: kCIOutputImageKey) as? CIImage
         }
 
         return image
@@ -195,6 +195,6 @@ class BlurAnnotation: Annotation {
      */
     init(startLocation: CGPoint, endLocation: CGPoint, image: CIImage) {
         self.image = image
-        super.init(startLocation: startLocation, endLocation: endLocation, strokeColor: .clearColor())
+        super.init(startLocation: startLocation, endLocation: endLocation, strokeColor: .clear())
     }
 }

--- a/PinpointKit/PinpointKit/Sources/AnnotationsView.swift
+++ b/PinpointKit/PinpointKit/Sources/AnnotationsView.swift
@@ -27,7 +27,7 @@ class AnnotationsView: UIView {
      */
     func moveViewIfAppropriate(_ view: UIView) {
         if let blurView = view as? BlurAnnotationView {
-            moveBlurViewAboveBlurViewsAndUnderOthers(blurView: blurView)
+            moveBlurViewAboveBlurViewsAndUnderOthers(blurView)
         }
     }
     
@@ -36,7 +36,7 @@ class AnnotationsView: UIView {
      
      - parameter blurView: The blur view to move.
      */
-    func moveBlurViewAboveBlurViewsAndUnderOthers(blurView: BlurAnnotationView) {
+    func moveBlurViewAboveBlurViewsAndUnderOthers(_ blurView: BlurAnnotationView) {
         var lastBlurViewIndex: Int?
         for (index, subview) in subviews.enumerated() {
             if subview is BlurAnnotationView && subview as? BlurAnnotationView != blurView {

--- a/PinpointKit/PinpointKit/Sources/AnnotationsView.swift
+++ b/PinpointKit/PinpointKit/Sources/AnnotationsView.swift
@@ -10,13 +10,13 @@ import UIKit
 
 /// A `UIView` subclass that displays annotations.
 class AnnotationsView: UIView {
-    override func addSubview(view: UIView) {
+    override func addSubview(_ view: UIView) {
         super.addSubview(view)
         moveViewIfAppropriate(view)
     }
     
-    override func bringSubviewToFront(view: UIView) {
-        super.bringSubviewToFront(view)
+    override func bringSubview(toFront view: UIView) {
+        super.bringSubview(toFront: view)
         moveViewIfAppropriate(view)
     }
     
@@ -25,7 +25,7 @@ class AnnotationsView: UIView {
      
      - parameter view: The view to potentially move.
      */
-    func moveViewIfAppropriate(view: UIView) {
+    func moveViewIfAppropriate(_ view: UIView) {
         if let blurView = view as? BlurAnnotationView {
             moveBlurViewAboveBlurViewsAndUnderOthers(blurView: blurView)
         }
@@ -36,16 +36,16 @@ class AnnotationsView: UIView {
      
      - parameter blurView: The blur view to move.
      */
-    func moveBlurViewAboveBlurViewsAndUnderOthers(blurView blurView: BlurAnnotationView) {
+    func moveBlurViewAboveBlurViewsAndUnderOthers(blurView: BlurAnnotationView) {
         var lastBlurViewIndex: Int?
-        for (index, subview) in subviews.enumerate() {
+        for (index, subview) in subviews.enumerated() {
             if subview is BlurAnnotationView && subview as? BlurAnnotationView != blurView {
                 lastBlurViewIndex = index
             }
         }
         
-        let index = lastBlurViewIndex?.successor() ?? 0
-        insertSubview(blurView, atIndex: index)
+        let index = ((lastBlurViewIndex?)! + 1) ?? 0
+        insertSubview(blurView, at: index)
     }
     
     override func tintColorDidChange() {

--- a/PinpointKit/PinpointKit/Sources/AnnotationsView.swift
+++ b/PinpointKit/PinpointKit/Sources/AnnotationsView.swift
@@ -44,7 +44,13 @@ class AnnotationsView: UIView {
             }
         }
         
-        let index = ((lastBlurViewIndex?)! + 1) ?? 0
+        let index: Int
+        if let lastIndex = lastBlurViewIndex {
+            index = lastIndex + 1
+        } else {
+            index = 0
+        }
+        
         insertSubview(blurView, at: index)
     }
     

--- a/PinpointKit/PinpointKit/Sources/ArrowAnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/ArrowAnnotationView.swift
@@ -17,7 +17,7 @@ public class ArrowAnnotationView: AnnotationView {
     var annotation: ArrowAnnotation? {
         didSet {
             setNeedsDisplay()
-            layer.shadowPath = annotation?.path?.CGPath
+            layer.shadowPath = annotation?.path?.cgPath
         }
     }
 
@@ -34,11 +34,11 @@ public class ArrowAnnotationView: AnnotationView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        opaque = false
-        contentMode = .Redraw
+        isOpaque = false
+        contentMode = .redraw
 
         layer.shadowOffset = CGSize.zero
-        layer.shadowColor = UIColor.blackColor().CGColor
+        layer.shadowColor = UIColor.black().cgColor
         layer.shadowOpacity = 1
         layer.shadowRadius = 4
     }
@@ -55,7 +55,7 @@ public class ArrowAnnotationView: AnnotationView {
         setNeedsDisplay()
     }
 
-    override public func drawRect(rect: CGRect) {
+    override public func draw(_ rect: CGRect) {
         tintColor.setFill()
         annotation?.strokeColor.setStroke()
 
@@ -64,20 +64,20 @@ public class ArrowAnnotationView: AnnotationView {
         path?.stroke()
     }
 
-    override public func pointInside(point: CGPoint, withEvent event: UIEvent?) -> Bool {
-        return annotation?.touchTargetPath?.containsPoint(point) ?? false
+    override public func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        return annotation?.touchTargetPath?.contains(point) ?? false
     }
 
 
     // MARK: - AnnotationView
 
-    override func setSecondControlPoint(point: CGPoint) {
+    override func setSecondControlPoint(_ point: CGPoint) {
         guard let previousAnnotation = annotation else { return }
         
         annotation = ArrowAnnotation(startLocation: previousAnnotation.startLocation, endLocation: point, strokeColor: previousAnnotation.strokeColor)
     }
 
-    override func moveControlPoints(translation: CGPoint) {
+    override func moveControlPoints(_ translation: CGPoint) {
         guard let previousAnnotation = annotation else { return }
         let startLocation = CGPoint(x: previousAnnotation.startLocation.x + translation.x, y: previousAnnotation.startLocation.y + translation.y)
         let endLocation = CGPoint(x: previousAnnotation.endLocation.x + translation.x, y: previousAnnotation.endLocation.y + translation.y)
@@ -85,7 +85,7 @@ public class ArrowAnnotationView: AnnotationView {
         annotation = ArrowAnnotation(startLocation: startLocation, endLocation: endLocation, strokeColor: previousAnnotation.strokeColor)
     }
     
-    override func scaleControlPoints(scale: CGFloat) {
+    override func scaleControlPoints(_ scale: CGFloat) {
         guard let previousAnnotation = annotation else { return }
         let startLocation = previousAnnotation.scaledPoint(previousAnnotation.startLocation, scale: scale)
         let endLocation = previousAnnotation.scaledPoint(previousAnnotation.endLocation, scale: scale)
@@ -114,8 +114,8 @@ private extension ArrowAnnotation {
         guard let path = path else { return nil }
         
         let outsideStrokeWidth = strokeWidth * 5.0
-        guard let strokedPath = CGPathCreateCopyByStrokingPath(path.CGPath, nil, outsideStrokeWidth, .Butt, .Bevel, 0) else { return nil }
+        guard let strokedPath = CGPath(copyByStroking: path.cgPath, transform: nil, lineWidth: outsideStrokeWidth, lineCap: .butt, lineJoin: .bevel, miterLimit: 0) else { return nil }
         
-        return UIBezierPath(CGPath: strokedPath)
+        return UIBezierPath(cgPath: strokedPath)
     }
 }

--- a/PinpointKit/PinpointKit/Sources/ArrowAnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/ArrowAnnotationView.swift
@@ -101,10 +101,7 @@ private extension ArrowAnnotation {
             return nil
         }
         
-        let path = UIBezierPath.arrowBezierPath(
-            startPoint: startLocation,
-            endPoint: endLocation
-        )
+        let path = UIBezierPath.arrowBezierPath(startLocation, endPoint: endLocation)
         
         path.lineWidth = strokeWidth
         return path

--- a/PinpointKit/PinpointKit/Sources/BarButtonItem.swift
+++ b/PinpointKit/PinpointKit/Sources/BarButtonItem.swift
@@ -18,8 +18,8 @@ extension UIBarButtonItem {
      - parameter action: The bar button item’s action.
      */
     convenience init(doneButtonWithTarget target: AnyObject?, font: UIFont, action: Selector) {
-        self.init(barButtonSystemItem: .Done, target: target, action: action)
+        self.init(barButtonSystemItem: .done, target: target, action: action)
         
-        setTitleTextAttributes([NSFontAttributeName: font], forState: .Normal)
+        setTitleTextAttributes([NSFontAttributeName: font], for: UIControlState())
     }
 }

--- a/PinpointKit/PinpointKit/Sources/BasicLogViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/BasicLogViewController.swift
@@ -25,8 +25,8 @@ public class BasicLogViewController: UIViewController, LogViewer {
     private let textView: UITextView = {
         let textView = UITextView()
         textView.translatesAutoresizingMaskIntoConstraints = false
-        textView.editable = false
-        textView.dataDetectorTypes = .None
+        textView.isEditable = false
+        textView.dataDetectorTypes = UIDataDetectorTypes()
 
         return textView
     }()
@@ -39,16 +39,16 @@ public class BasicLogViewController: UIViewController, LogViewer {
         func setUpTextView() {
             view.addSubview(textView)
             
-            textView.centerXAnchor.constraintEqualToAnchor(view.centerXAnchor, constant: 0).active = true
-            textView.centerYAnchor.constraintEqualToAnchor(view.centerYAnchor, constant: 0).active = true
-            textView.widthAnchor.constraintEqualToAnchor(view.widthAnchor, constant: 0).active = true
-            textView.heightAnchor.constraintEqualToAnchor(view.heightAnchor, constant: 0).active = true
+            textView.centerXAnchor.constraint(equalTo: view.centerXAnchor, constant: 0).isActive = true
+            textView.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: 0).isActive = true
+            textView.widthAnchor.constraint(equalTo: view.widthAnchor, constant: 0).isActive = true
+            textView.heightAnchor.constraint(equalTo: view.heightAnchor, constant: 0).isActive = true
         }
         
         setUpTextView()
     }
     
-    public override func viewWillAppear(animated: Bool) {
+    public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
         textView.scrollRangeToVisible(NSRange(location: (textView.text as NSString).length, length: 0))
@@ -56,10 +56,10 @@ public class BasicLogViewController: UIViewController, LogViewer {
     
     // MARK: - LogViewer
     
-    public func viewLog(collector: LogCollector, fromViewController viewController: UIViewController) {
-        let logText = collector.retrieveLogs().joinWithSeparator("\n")
+    public func viewLog(_ collector: LogCollector, fromViewController viewController: UIViewController) {
+        let logText = collector.retrieveLogs().joined(separator: "\n")
         textView.text = logText
         
-        viewController.showViewController(self, sender: viewController)
+        viewController.show(self, sender: viewController)
     }
 }

--- a/PinpointKit/PinpointKit/Sources/BezierPath.swift
+++ b/PinpointKit/PinpointKit/Sources/BezierPath.swift
@@ -19,7 +19,7 @@ extension UIBezierPath {
      
      - returns: A `UIBezierPath` in the shape of an arrow.
      */
-    static func arrowBezierPath(startPoint: CGPoint, endPoint: CGPoint) -> UIBezierPath {
+    static func arrowBezierPath(_ startPoint: CGPoint, endPoint: CGPoint) -> UIBezierPath {
         let length = hypot(endPoint.x - startPoint.x, endPoint.y - startPoint.y)
 
         // Shape 267x120 from PaintCode. 0 is the mid Y of the arrow to match the original arrow Y.

--- a/PinpointKit/PinpointKit/Sources/BezierPath.swift
+++ b/PinpointKit/PinpointKit/Sources/BezierPath.swift
@@ -19,45 +19,45 @@ extension UIBezierPath {
      
      - returns: A `UIBezierPath` in the shape of an arrow.
      */
-    static func arrowBezierPath(startPoint startPoint: CGPoint, endPoint: CGPoint) -> UIBezierPath {
+    static func arrowBezierPath(startPoint: CGPoint, endPoint: CGPoint) -> UIBezierPath {
         let length = hypot(endPoint.x - startPoint.x, endPoint.y - startPoint.y)
 
         // Shape 267x120 from PaintCode. 0 is the mid Y of the arrow to match the original arrow Y.
         let bezierPath = UIBezierPath()
-        bezierPath.moveToPoint(CGPoint(x: 197.29, y: -57.56))
-        bezierPath.addLineToPoint(CGPoint(x: 194.32, y: -54.58))
-        bezierPath.addCurveToPoint(CGPoint(x: 193.82, y: -43.36), controlPoint1: CGPoint(x: 191.31, y: -51.53), controlPoint2: CGPoint(x: 191.09, y: -46.67))
-        bezierPath.addLineToPoint(CGPoint(x: 215.25, y: -17.45))
-        bezierPath.addCurveToPoint(CGPoint(x: 213.11, y: -12.74), controlPoint1: CGPoint(x: 216.79, y: -15.59), controlPoint2: CGPoint(x: 215.5, y: -12.77))
-        bezierPath.addLineToPoint(CGPoint(x: 8.15, y: -10.22))
-        bezierPath.addCurveToPoint(CGPoint(x: 0, y: -1.9), controlPoint1: CGPoint(x: 3.63, y: -10.17), controlPoint2: CGPoint(x: 0, y: -6.46))
-        bezierPath.addLineToPoint(CGPoint(x: 0, y: 1.81))
-        bezierPath.addCurveToPoint(CGPoint(x: 8.15, y: 10.13), controlPoint1: CGPoint(x: 0, y: 6.37), controlPoint2: CGPoint(x: 3.63, y: 10.08))
-        bezierPath.addLineToPoint(CGPoint(x: 213.18, y: 12.65))
-        bezierPath.addCurveToPoint(CGPoint(x: 215.33, y: 17.36), controlPoint1: CGPoint(x: 215.58, y: 12.68), controlPoint2: CGPoint(x: 216.86, y: 15.5))
-        bezierPath.addLineToPoint(CGPoint(x: 193.82, y: 43.36))
-        bezierPath.addCurveToPoint(CGPoint(x: 194.32, y: 54.58), controlPoint1: CGPoint(x: 191.09, y: 46.67), controlPoint2: CGPoint(x: 191.31, y: 51.53))
-        bezierPath.addLineToPoint(CGPoint(x: 197.29, y: 57.56))
-        bezierPath.addCurveToPoint(CGPoint(x: 208.95, y: 57.56), controlPoint1: CGPoint(x: 200.51, y: 60.81), controlPoint2: CGPoint(x: 205.73, y: 60.81))
-        bezierPath.addLineToPoint(CGPoint(x: 266, y: -0))
-        bezierPath.addLineToPoint(CGPoint(x: 208.95, y: -57.56))
-        bezierPath.addCurveToPoint(CGPoint(x: 197.29, y: -57.56), controlPoint1: CGPoint(x: 205.73, y: -60.81), controlPoint2: CGPoint(x: 200.51, y: -60.81))
-        bezierPath.closePath()
+        bezierPath.move(to: CGPoint(x: 197.29, y: -57.56))
+        bezierPath.addLine(to: CGPoint(x: 194.32, y: -54.58))
+        bezierPath.addCurve(to: CGPoint(x: 193.82, y: -43.36), controlPoint1: CGPoint(x: 191.31, y: -51.53), controlPoint2: CGPoint(x: 191.09, y: -46.67))
+        bezierPath.addLine(to: CGPoint(x: 215.25, y: -17.45))
+        bezierPath.addCurve(to: CGPoint(x: 213.11, y: -12.74), controlPoint1: CGPoint(x: 216.79, y: -15.59), controlPoint2: CGPoint(x: 215.5, y: -12.77))
+        bezierPath.addLine(to: CGPoint(x: 8.15, y: -10.22))
+        bezierPath.addCurve(to: CGPoint(x: 0, y: -1.9), controlPoint1: CGPoint(x: 3.63, y: -10.17), controlPoint2: CGPoint(x: 0, y: -6.46))
+        bezierPath.addLine(to: CGPoint(x: 0, y: 1.81))
+        bezierPath.addCurve(to: CGPoint(x: 8.15, y: 10.13), controlPoint1: CGPoint(x: 0, y: 6.37), controlPoint2: CGPoint(x: 3.63, y: 10.08))
+        bezierPath.addLine(to: CGPoint(x: 213.18, y: 12.65))
+        bezierPath.addCurve(to: CGPoint(x: 215.33, y: 17.36), controlPoint1: CGPoint(x: 215.58, y: 12.68), controlPoint2: CGPoint(x: 216.86, y: 15.5))
+        bezierPath.addLine(to: CGPoint(x: 193.82, y: 43.36))
+        bezierPath.addCurve(to: CGPoint(x: 194.32, y: 54.58), controlPoint1: CGPoint(x: 191.09, y: 46.67), controlPoint2: CGPoint(x: 191.31, y: 51.53))
+        bezierPath.addLine(to: CGPoint(x: 197.29, y: 57.56))
+        bezierPath.addCurve(to: CGPoint(x: 208.95, y: 57.56), controlPoint1: CGPoint(x: 200.51, y: 60.81), controlPoint2: CGPoint(x: 205.73, y: 60.81))
+        bezierPath.addLine(to: CGPoint(x: 266, y: -0))
+        bezierPath.addLine(to: CGPoint(x: 208.95, y: -57.56))
+        bezierPath.addCurve(to: CGPoint(x: 197.29, y: -57.56), controlPoint1: CGPoint(x: 205.73, y: -60.81), controlPoint2: CGPoint(x: 200.51, y: -60.81))
+        bezierPath.close()
         bezierPath.usesEvenOddFillRule = true
         
-        bezierPath.applyTransform(transformForStartPoint(startPoint, endPoint: endPoint, length: length))
+        bezierPath.apply(transformForStartPoint(startPoint, endPoint: endPoint, length: length))
         
         return bezierPath
     }
     
-    private static func transformForStartPoint(startPoint: CGPoint, endPoint: CGPoint, length: CGFloat) -> CGAffineTransform {
+    private static func transformForStartPoint(_ startPoint: CGPoint, endPoint: CGPoint, length: CGFloat) -> CGAffineTransform {
         let cosine = (endPoint.x - startPoint.x) / length
         let sine = (endPoint.y - startPoint.y) / length
         
         let scale: CGFloat = length / PaintCodeArrowPathWidth
-        let scaleTransform = CGAffineTransformMakeScale(scale, scale)
+        let scaleTransform = CGAffineTransform(scaleX: scale, y: scale)
 
         let rotationAndSizeTransform = CGAffineTransform(a: cosine, b: sine, c: -sine, d: cosine, tx: startPoint.x, ty: startPoint.y)
-        return CGAffineTransformConcat(scaleTransform, rotationAndSizeTransform)
+        return scaleTransform.concat(rotationAndSizeTransform)
     }
 }

--- a/PinpointKit/PinpointKit/Sources/BlurAnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/BlurAnnotationView.swift
@@ -101,15 +101,16 @@ public class BlurAnnotationView: AnnotationView, GLKViewDelegate {
         super.draw(rect)
         
         if drawsBorder {
-            let context = UIGraphicsGetCurrentContext()
+            guard let context = UIGraphicsGetCurrentContext() else { return }
+            
             tintColor?.withAlphaComponent(self.dynamicType.BorderAlpha).setStroke()
             
             // Since this draws under the GLKView, and strokes extend both inside and outside, we have to double the intended width.
             let strokeWidth: CGFloat = 1.0
-            context?.setLineWidth(strokeWidth * 2.0)
+            context.setLineWidth(strokeWidth * 2.0)
             
             let rect = annotationFrame ?? CGRect.zero
-            context?.stroke(rect)
+            context.stroke(rect)
         }
     }
         

--- a/PinpointKit/PinpointKit/Sources/BoxAnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/BoxAnnotationView.swift
@@ -16,7 +16,7 @@ public class BoxAnnotationView: AnnotationView {
     /// The corresponding annotation.
     var annotation: BoxAnnotation? {
         didSet {
-            layer.shadowPath = annotation.flatMap(PathForDrawingBoxAnnotation)?.CGPath
+            layer.shadowPath = annotation.flatMap(PathForDrawingBoxAnnotation)?.cgPath
             setNeedsDisplay()
         }
     }
@@ -35,11 +35,11 @@ public class BoxAnnotationView: AnnotationView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        opaque = false
-        contentMode = .Redraw
+        isOpaque = false
+        contentMode = .redraw
 
         layer.shadowOffset = CGSize.zero
-        layer.shadowColor = UIColor.blackColor().CGColor
+        layer.shadowColor = UIColor.black().cgColor
         layer.shadowOpacity = 1
         layer.shadowRadius = 4
     }
@@ -56,7 +56,7 @@ public class BoxAnnotationView: AnnotationView {
         setNeedsDisplay()
     }
 
-    override public func drawRect(rect: CGRect) {
+    override public func draw(_ rect: CGRect) {
         tintColor.setFill()
         annotation?.strokeColor.setStroke()
 
@@ -65,20 +65,20 @@ public class BoxAnnotationView: AnnotationView {
         path?.stroke()
     }
 
-    override public func pointInside(point: CGPoint, withEvent event: UIEvent?) -> Bool {
-        return annotation.flatMap(PathForPointInsideBoxAnnotation).map { $0.containsPoint(point) } ?? false
+    override public func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        return annotation.flatMap(PathForPointInsideBoxAnnotation).map { $0.contains(point) } ?? false
     }
 
 
     // MARK: - AnnotationView
 
-    override func setSecondControlPoint(point: CGPoint) {
+    override func setSecondControlPoint(_ point: CGPoint) {
         guard let previousAnnotation = annotation else { return }
 
         annotation = BoxAnnotation(startLocation: previousAnnotation.startLocation, endLocation: point, strokeColor: previousAnnotation.strokeColor)
     }
 
-    override func moveControlPoints(translation: CGPoint) {
+    override func moveControlPoints(_ translation: CGPoint) {
         guard let previousAnnotation = annotation else { return }
         let startLocation = CGPoint(x: previousAnnotation.startLocation.x + translation.x, y: previousAnnotation.startLocation.y + translation.y)
         let endLocation = CGPoint(x: previousAnnotation.endLocation.x + translation.x, y: previousAnnotation.endLocation.y + translation.y)
@@ -86,7 +86,7 @@ public class BoxAnnotationView: AnnotationView {
         annotation = BoxAnnotation(startLocation: startLocation, endLocation: endLocation, strokeColor: previousAnnotation.strokeColor)
     }
     
-    override func scaleControlPoints(scale: CGFloat) {
+    override func scaleControlPoints(_ scale: CGFloat) {
         guard let previousAnnotation = annotation else { return }
         let startLocation = previousAnnotation.scaledPoint(previousAnnotation.startLocation, scale: scale)
         let endLocation = previousAnnotation.scaledPoint(previousAnnotation.endLocation, scale: scale)
@@ -95,7 +95,7 @@ public class BoxAnnotationView: AnnotationView {
     }
 }
 
-private func PathForDrawingBoxAnnotation(annotation: BoxAnnotation) -> UIBezierPath? {
+private func PathForDrawingBoxAnnotation(_ annotation: BoxAnnotation) -> UIBezierPath? {
     let frame = annotation.frame
     let strokeWidth = annotation.strokeWidth
     let borderWidth = annotation.borderWidth
@@ -112,25 +112,25 @@ private func PathForDrawingBoxAnnotation(annotation: BoxAnnotation) -> UIBezierP
         return nil
     }
     
-    let firstPath = CGPathCreateWithRoundedRect(innerBox, cornerRadius, cornerRadius, nil)
-    let secondPath = CGPathCreateCopyByStrokingPath(firstPath, nil, borderWidth + strokeWidth, .Butt, .Bevel, 100)
+    let firstPath = CGPath(roundedRect: innerBox, cornerWidth: cornerRadius, cornerHeight: cornerRadius, transform: nil)
+    let secondPath = CGPath(copyByStroking: firstPath, transform: nil, lineWidth: borderWidth + strokeWidth, lineCap: .butt, lineJoin: .bevel, miterLimit: 100)
     
     guard let strokePath = secondPath else { return nil }
     
-    let path = UIBezierPath(CGPath: strokePath)
+    let path = UIBezierPath(cgPath: strokePath)
     path.lineWidth = strokeWidth
-    path.closePath()
+    path.close()
     return path
 }
 
-private func PathForPointInsideBoxAnnotation(annotation: BoxAnnotation) -> UIBezierPath? {
+private func PathForPointInsideBoxAnnotation(_ annotation: BoxAnnotation) -> UIBezierPath? {
     let outsideStrokeWidth = annotation.borderWidth * 2.0
     
     return PathForDrawingBoxAnnotation(annotation)
         .flatMap { path in
-            CGPathCreateCopyByStrokingPath(path.CGPath, nil, outsideStrokeWidth, .Butt, .Bevel, 0)
+            CGPath(copyByStroking: path.cgPath, transform: nil, lineWidth: outsideStrokeWidth, lineCap: .butt, lineJoin: .bevel, miterLimit: 0)
         }
         .map { path in
-            UIBezierPath(CGPath: path)
+            UIBezierPath(cgPath: path)
     }
 }

--- a/PinpointKit/PinpointKit/Sources/CheckmarkCell.swift
+++ b/PinpointKit/PinpointKit/Sources/CheckmarkCell.swift
@@ -14,14 +14,14 @@ final class CheckmarkCell: UITableViewCell {
     /// Controls whether the receiver displays a checkmark in `imageView`.
     var isChecked: Bool = false {
         didSet {
-            imageView?.hidden = !isChecked
+            imageView?.isHidden = !isChecked
         }
     }
     
     override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
-        imageView?.image = UIImage(named: "Checkmark", inBundle: NSBundle(forClass: self.dynamicType), compatibleWithTraitCollection: nil)
+        imageView?.image = UIImage(named: "Checkmark", in: Bundle(for: self.dynamicType), compatibleWith: nil)
     }
     
     required init?(coder aDecoder: NSCoder) {

--- a/PinpointKit/PinpointKit/Sources/Editing/AnnotationViewFactory.swift
+++ b/PinpointKit/PinpointKit/Sources/Editing/AnnotationViewFactory.swift
@@ -28,26 +28,26 @@ struct AnnotationViewFactory {
      */
     func annotationView() -> AnnotationView {
         switch tool {
-        case .Arrow:
+        case .arrow:
             let view = ArrowAnnotationView()
             view.annotation = ArrowAnnotation(startLocation: currentLocation, endLocation: currentLocation, strokeColor: strokeColor)
             return view
-        case .Box:
+        case .box:
             let view = BoxAnnotationView()
             view.annotation = BoxAnnotation(startLocation: currentLocation, endLocation: currentLocation, strokeColor: strokeColor)
             return view
-        case .Text:
+        case .text:
             let view = TextAnnotationView()
             let minimumSize = view.minimumTextSize
             let endLocation = CGPoint(x: currentLocation.x + minimumSize.width, y: currentLocation.y + minimumSize.height)
             view.annotation = Annotation(startLocation: currentLocation, endLocation: endLocation, strokeColor: strokeColor)
             return view
-        case .Blur:
+        case .blur:
             let view = BlurAnnotationView()
             view.drawsBorder = true
             
             if let image = image {
-                let CIImage = CoreImage.CIImage(CGImage: image)
+                let CIImage = CoreImage.CIImage(cgImage: image)
                 view.annotation = BlurAnnotation(startLocation: currentLocation, endLocation: currentLocation, image: CIImage)
             }
             

--- a/PinpointKit/PinpointKit/Sources/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Editing/EditImageViewController.swift
@@ -520,8 +520,8 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
     
     private func handleUpdateAnnotationGestureRecognizerChanged(_ gestureRecognizer: UIPanGestureRecognizer) {
         let currentLocation = gestureRecognizer.location(in: gestureRecognizer.view)
-        let previousLocation = previousUpdateAnnotationPanGestureRecognizerLocation
-        let offset = CGPoint(x: currentLocation.x - (previousLocation?.x)!, y: currentLocation.y - (previousLocation?.y)!)
+        let previousLocation: CGPoint = previousUpdateAnnotationPanGestureRecognizerLocation
+        let offset = CGPoint(x: currentLocation.x - previousLocation.x, y: currentLocation.y - previousLocation.y)
         currentAnnotationView?.moveControlPoints(offset)
         previousUpdateAnnotationPanGestureRecognizerLocation = gestureRecognizer.location(in: gestureRecognizer.view)
     }

--- a/PinpointKit/PinpointKit/Sources/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Editing/EditImageViewController.swift
@@ -35,12 +35,12 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
     // MARK: - Properties
     
     private lazy var segmentedControl: UISegmentedControl = { [unowned self] in
-        let segmentArray = [Tool.Arrow, Tool.Box, Tool.Text, Tool.Blur]
+        let segmentArray = [Tool.arrow, Tool.box, Tool.text, Tool.blur]
         
         let view = UISegmentedControl(items: segmentArray.map { $0.segmentedControlItem })
         view.selectedSegmentIndex = 0
         
-        let textToolIndex = segmentArray.indexOf(Tool.Text)
+        let textToolIndex = segmentArray.index(of: Tool.text)
         
         if let index = textToolIndex {
             let segment = view.subviews[index]
@@ -48,10 +48,10 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         }
         
         for i in 0..<view.numberOfSegments {
-            view.setWidth(54, forSegmentAtIndex: i)
+            view.setWidth(54, forSegmentAt: i)
         }
         
-        view.addTarget(self, action: #selector(EditImageViewController.toolChanged(_:)), forControlEvents: .ValueChanged)
+        view.addTarget(self, action: #selector(EditImageViewController.toolChanged(_:)), for: .valueChanged)
         
         return view
         }()
@@ -82,13 +82,13 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
     private var previousUpdateAnnotationPanGestureRecognizerLocation: CGPoint!
     
     private lazy var keyboardAvoider: KeyboardAvoider? = {
-        guard let window = UIApplication.sharedApplication().keyWindow else { assertionFailure("PinpointKit did not find a keyWindow."); return nil }
+        guard let window = UIApplication.shared().keyWindow else { assertionFailure("PinpointKit did not find a keyWindow."); return nil }
         
         return KeyboardAvoider(window: window)
     }()
     
     private lazy var closeBarButtonItem: UIBarButtonItem = {
-        UIBarButtonItem(image: UIImage(named: "CloseButtonX", inBundle: .pinpointKitBundle(), compatibleWithTraitCollection: nil), landscapeImagePhone: nil, style: .Plain, target: self, action: #selector(EditImageViewController.closeButtonTapped(_:)))
+        UIBarButtonItem(image: UIImage(named: "CloseButtonX", in: .pinpointKitBundle(), compatibleWith: nil), landscapeImagePhone: nil, style: .plain, target: self, action: #selector(EditImageViewController.closeButtonTapped(_:)))
     }()
     
     private lazy var doneBarButtonItem: UIBarButtonItem = {
@@ -103,13 +103,13 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
     private var currentAnnotationView: AnnotationView? {
         didSet {
             if let oldTextAnnotationView = oldValue as? TextAnnotationView {
-                NSNotificationCenter.defaultCenter().removeObserver(self, name: UITextViewTextDidEndEditingNotification, object: oldTextAnnotationView.textView)
+                NotificationCenter.default().removeObserver(self, name: NSNotification.Name.UITextViewTextDidEndEditing, object: oldTextAnnotationView.textView)
             }
             
             if let currentTextAnnotationView = currentTextAnnotationView {
                 keyboardAvoider?.triggerViews = [currentTextAnnotationView.textView]
                 
-                NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(EditImageViewController.forceEndEditingTextView), name: UITextViewTextDidEndEditingNotification, object: currentTextAnnotationView.textView)
+                NotificationCenter.default().addObserver(self, selector: #selector(EditImageViewController.forceEndEditingTextView), name: NSNotification.Name.UITextViewTextDidEndEditing, object: currentTextAnnotationView.textView)
             }
         }
     }
@@ -159,7 +159,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
     }
     
     deinit {
-        NSNotificationCenter.defaultCenter().removeObserver(self)
+        NotificationCenter.default().removeObserver(self)
         createAnnotationPanGestureRecognizer.delegate = nil
         updateAnnotationPanGestureRecognizer.delegate = nil
         createOrUpdateAnnotationTapGestureRecognizer.delegate = nil
@@ -173,7 +173,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         return true
     }
     
-    public override func canPerformAction(action: Selector, withSender sender: AnyObject?) -> Bool {
+    public override func canPerformAction(_ action: Selector, withSender sender: AnyObject?) -> Bool {
         let textViewIsEditing = currentTextAnnotationView?.textView.isFirstResponder() ?? false
         return action == #selector(EditImageViewController.deleteSelectedAnnotationView) && !textViewIsEditing
     }
@@ -187,7 +187,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         
         navigationItem.rightBarButtonItem = doneBarButtonItem
         
-        view.backgroundColor = UIColor.whiteColor()
+        view.backgroundColor = UIColor.white()
         view.addSubview(imageView)
         view.addSubview(annotationsView)
         
@@ -197,7 +197,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         doubleTapGestureRecognizer.numberOfTapsRequired = 2
         doubleTapGestureRecognizer.delegate = self
         
-        createOrUpdateAnnotationTapGestureRecognizer.requireGestureRecognizerToFail(doubleTapGestureRecognizer)
+        createOrUpdateAnnotationTapGestureRecognizer.require(toFail: doubleTapGestureRecognizer)
         
         view.addGestureRecognizer(touchDownGestureRecognizer)
         view.addGestureRecognizer(doubleTapGestureRecognizer)
@@ -221,20 +221,20 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         setupConstraints()
     }
     
-    public override func viewWillAppear(animated: Bool) {
+    public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
         navigationController?.hidesBarsOnTap = true
         navigationController?.setNavigationBarHidden(true, animated: false)
     }
     
-    public override func viewDidAppear(animated: Bool) {
+    public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
         navigationController?.setNavigationBarHidden(false, animated: true)
     }
     
-    public override func viewWillDisappear(animated: Bool) {
+    public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         navigationController?.hidesBarsOnTap = true
     }
@@ -252,7 +252,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         return true
     }
     
-    public override func traitCollectionDidChange(previousTraitCollection: UITraitCollection?) {
+    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         setNeedsStatusBarAppearanceUpdate()
     }
     
@@ -261,17 +261,17 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
     }
     
     public override func supportedInterfaceOrientations() -> UIInterfaceOrientationMask {
-        return imageIsLandscape() ? .Landscape : [.Portrait, .PortraitUpsideDown]
+        return imageIsLandscape() ? .landscape : [.portrait, .portraitUpsideDown]
     }
     
     public override func preferredInterfaceOrientationForPresentation() -> UIInterfaceOrientation {
-        var landscapeOrientation = UIInterfaceOrientation.LandscapeRight
-        var portraitOrientation = UIInterfaceOrientation.Portrait
+        var landscapeOrientation = UIInterfaceOrientation.landscapeRight
+        var portraitOrientation = UIInterfaceOrientation.portrait
         
-        if traitCollection.userInterfaceIdiom == .Pad {
-            let deviceOrientation = UIDevice.currentDevice().orientation
-            landscapeOrientation = (deviceOrientation == .LandscapeRight ? .LandscapeLeft : .LandscapeRight)
-            portraitOrientation = (deviceOrientation == .PortraitUpsideDown ? .PortraitUpsideDown : .Portrait)
+        if traitCollection.userInterfaceIdiom == .pad {
+            let deviceOrientation = UIDevice.current().orientation
+            landscapeOrientation = (deviceOrientation == .landscapeRight ? .landscapeLeft : .landscapeRight)
+            portraitOrientation = (deviceOrientation == .portraitUpsideDown ? .portraitUpsideDown : .portrait)
         }
         
         return imageIsLandscape() ? landscapeOrientation : portraitOrientation
@@ -285,57 +285,57 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
             "annotationsView": annotationsView
         ]
         
-        view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("|[imageView]|", options: [], metrics: nil, views: views))
-        view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("|[annotationsView]|", options: [], metrics: nil, views: views))
+        view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "|[imageView]|", options: [], metrics: nil, views: views))
+        view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "|[annotationsView]|", options: [], metrics: nil, views: views))
         
-        view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|[imageView]|", options: [], metrics: nil, views: views))
-        view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|[annotationsView]|", options: [], metrics: nil, views: views))
+        view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|[imageView]|", options: [], metrics: nil, views: views))
+        view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|[annotationsView]|", options: [], metrics: nil, views: views))
     }
     
     private func newCloseScreenshotAlert() -> UIAlertController {
-        let alert = UIAlertController(title: nil, message: NSLocalizedString("Your edits to this screenshot will be lost unless you share it or save a copy.", comment: "Alert title for closing a screenshot that has annotations that hasn’t been shared."), preferredStyle: .ActionSheet)
-        alert.addAction(UIAlertAction(title: NSLocalizedString("Discard", comment: "Alert button title to close a screenshot and discard edits"), style: .Destructive) { action in
+        let alert = UIAlertController(title: nil, message: NSLocalizedString("Your edits to this screenshot will be lost unless you share it or save a copy.", comment: "Alert title for closing a screenshot that has annotations that hasn’t been shared."), preferredStyle: .actionSheet)
+        alert.addAction(UIAlertAction(title: NSLocalizedString("Discard", comment: "Alert button title to close a screenshot and discard edits"), style: .destructive) { action in
             self.delegate?.editorWillDismiss(self, screenshot: self.view.pinpoint_screenshot)
-            self.dismissViewControllerAnimated(true, completion: nil)
+            self.dismiss(animated: true, completion: nil)
         })
         
-        alert.addAction(UIAlertAction(title: NSLocalizedString("Cancel", comment: "Alert button title to cancel the alert."), style: .Cancel, handler: nil))
+        alert.addAction(UIAlertAction(title: NSLocalizedString("Cancel", comment: "Alert button title to cancel the alert."), style: .cancel, handler: nil))
         return alert
     }
     
-    @objc private func closeButtonTapped(button: UIBarButtonItem) {
+    @objc private func closeButtonTapped(_ button: UIBarButtonItem) {
         guard let image = imageView.image else { assertionFailure(); return }
         
         if let delegate = self.delegate {
             if delegate.editorShouldDismiss(self, screenshot: image) {
                 delegate.editorWillDismiss(self, screenshot: image)
                 
-                dismissViewControllerAnimated(true, completion: nil)
+                dismiss(animated: true, completion: nil)
             }
         } else {
-            dismissViewControllerAnimated(true, completion: nil)
+            dismiss(animated: true, completion: nil)
         }
     }
     
-    @objc private func doneButtonTapped(button: UIBarButtonItem) {
+    @objc private func doneButtonTapped(_ button: UIBarButtonItem) {
         if let delegate = self.delegate {
             if delegate.editorShouldDismiss(self, screenshot: self.view.pinpoint_screenshot) {
                 self.delegate?.editorWillDismiss(self, screenshot: self.view.pinpoint_screenshot)
                 
-                dismissViewControllerAnimated(true, completion: nil)
+                dismiss(animated: true, completion: nil)
             }
         } else {
-            dismissViewControllerAnimated(true, completion: nil)
+            dismiss(animated: true, completion: nil)
         }
     }
     
-    @objc private func handleTouchDownGestureRecognizer(gestureRecognizer: UILongPressGestureRecognizer) {
-        if gestureRecognizer.state == .Began {
+    @objc private func handleTouchDownGestureRecognizer(_ gestureRecognizer: UILongPressGestureRecognizer) {
+        if gestureRecognizer.state == .began {
             let possibleAnnotationView = annotationViewWithGestureRecognizer(gestureRecognizer)
             let annotationViewIsNotBlurView = !(possibleAnnotationView is BlurAnnotationView)
             
             if let annotationView = possibleAnnotationView {
-                annotationsView.bringSubviewToFront(annotationView)
+                annotationsView.bringSubview(toFront: annotationView)
                 
                 if annotationViewIsNotBlurView {
                     navigationController?.barHideOnTapGestureRecognizer.failRecognizing()
@@ -359,7 +359,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         }
     }
     
-    private func annotationViewWithGestureRecognizer(gestureRecognizer: UIGestureRecognizer) -> AnnotationView? {
+    private func annotationViewWithGestureRecognizer(_ gestureRecognizer: UIGestureRecognizer) -> AnnotationView? {
         let view = annotationsView
         if gestureRecognizer is UIPinchGestureRecognizer {
             var annotationViews: [AnnotationView] = []
@@ -367,7 +367,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
             let numberOfTouches = gestureRecognizer.numberOfTouches()
             
             for index in 0..<numberOfTouches {
-                if let annotationView = annotationViewInView(view, withLocation: gestureRecognizer.locationOfTouch(index, inView: view)) {
+                if let annotationView = annotationViewInView(view, withLocation: gestureRecognizer.location(ofTouch: index, in: view)) {
                     annotationViews.append(annotationView)
                 }
             }
@@ -378,11 +378,11 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
             return annotationViewsFiltered.count == numberOfTouches ? annotationView : nil
         }
         
-        return annotationViewInView(view, withLocation: gestureRecognizer.locationInView(view))
+        return annotationViewInView(view, withLocation: gestureRecognizer.location(in: view))
     }
     
-    private func annotationViewInView(view: UIView, withLocation location: CGPoint) -> AnnotationView? {
-        let hitView = view.hitTest(location, withEvent: nil)
+    private func annotationViewInView(_ view: UIView, withLocation location: CGPoint) -> AnnotationView? {
+        let hitView = view.hitTest(location, with: nil)
         let hitTextView = hitView as? UITextView
         let hitTextViewSuperview = hitTextView?.superview as? AnnotationView
         let hitAnnotationView = hitView as? AnnotationView
@@ -395,7 +395,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
 
         let imagePixelSize = CGSize(width: imageSize.width * imageScale, height: imageSize.height * imageScale)
         
-        let portraitPixelSize = UIScreen.mainScreen().portraitPixelSize()
+        let portraitPixelSize = UIScreen.main().portraitPixelSize()
         return CGFloat(imagePixelSize.width) == portraitPixelSize.height && CGFloat(imagePixelSize.height) == portraitPixelSize.width
     }
     
@@ -404,11 +404,11 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         currentTextAnnotationView.beginEditing()
         
         guard let buttonFont = interfaceCustomization?.appearance.editorTextAnnotationDoneButtonFont else { assertionFailure(); return }
-        let dismissButton = UIBarButtonItem(title: interfaceCustomization?.interfaceText.textEditingDismissButtonTitle, style: .Done, target: self, action: #selector(EditImageViewController.endEditingTextViewIfFirstResponder))
-        dismissButton.setTitleTextAttributes([NSFontAttributeName: buttonFont], forState: .Normal)
+        let dismissButton = UIBarButtonItem(title: interfaceCustomization?.interfaceText.textEditingDismissButtonTitle, style: .done, target: self, action: #selector(EditImageViewController.endEditingTextViewIfFirstResponder))
+        dismissButton.setTitleTextAttributes([NSFontAttributeName: buttonFont], for: UIControlState())
         
-        navigationItem.setRightBarButtonItem(dismissButton, animated: true)
-        navigationItem.setLeftBarButtonItem(nil, animated: true)
+        navigationItem.setRightBarButton(dismissButton, animated: true)
+        navigationItem.setLeftBarButton(nil, animated: true)
     }
     
     @objc private func forceEndEditingTextView() {
@@ -419,7 +419,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         endEditingTextView(true)
     }
     
-    private func endEditingTextView(checksFirstResponder: Bool = true) {
+    private func endEditingTextView(_ checksFirstResponder: Bool = true) {
         if let textView = currentTextAnnotationView?.textView where !checksFirstResponder || textView.isFirstResponder() {
             textView.resignFirstResponder()
             
@@ -427,7 +427,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
                 currentTextAnnotationView?.removeFromSuperview()
             }
             
-            navigationItem.setRightBarButtonItem(doneBarButtonItem, animated: true)
+            navigationItem.setRightBarButton(doneBarButtonItem, animated: true)
             
             currentAnnotationView = nil
         }
@@ -440,17 +440,17 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         currentAnnotationView = isEditingTextView ? currentAnnotationView : nil
     }
     
-    @objc private func toolChanged(segmentedControl: UISegmentedControl) {
+    @objc private func toolChanged(_ segmentedControl: UISegmentedControl) {
         endEditingTextView()
         
         // Disable the bar hiding behavior when selecting the text tool. Enable for all others.
-        navigationController?.barHideOnTapGestureRecognizer.enabled = currentTool != .Text
+        navigationController?.barHideOnTapGestureRecognizer.isEnabled = currentTool != .text
     }
     
     private func updateInterfaceCustomization() {
         guard let appearance = interfaceCustomization?.appearance else { assertionFailure(); return }
-        segmentedControl.setTitleTextAttributes([NSFontAttributeName: appearance.editorTextAnnotationSegmentFont], forState: UIControlState.Normal)
-        UITextView.appearanceWhenContainedInInstancesOfClasses([TextAnnotationView.self]).font = appearance.editorTextAnnotationFont
+        segmentedControl.setTitleTextAttributes([NSFontAttributeName: appearance.editorTextAnnotationSegmentFont], for: UIControlState())
+        UITextView.whenContained(inInstancesOfClasses: [TextAnnotationView.self]).font = appearance.editorTextAnnotationFont
         
         if let annotationFillColor = appearance.annotationFillColor {
             annotationsView.tintColor = annotationFillColor
@@ -459,80 +459,80 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
     
     // MARK: - Create annotations
     
-    @objc private func handleCreateAnnotationGestureRecognizer(gestureRecognizer: UIPanGestureRecognizer) {
+    @objc private func handleCreateAnnotationGestureRecognizer(_ gestureRecognizer: UIPanGestureRecognizer) {
         switch gestureRecognizer.state {
-        case .Began:
+        case .began:
             handleCreateAnnotationGestureRecognizerBegan(gestureRecognizer)
-        case .Changed:
+        case .changed:
             handleCreateAnnotationGestureRecognizerChanged(gestureRecognizer)
-        case .Cancelled, .Failed, .Ended:
+        case .cancelled, .failed, .ended:
             handleGestureRecognizerFinished()
         default:
             break
         }
     }
     
-    private func handleCreateAnnotationGestureRecognizerBegan(gestureRecognizer: UIGestureRecognizer) {
+    private func handleCreateAnnotationGestureRecognizerBegan(_ gestureRecognizer: UIGestureRecognizer) {
         guard let currentTool = currentTool else { return }
         guard let annotationStrokeColor = interfaceCustomization?.appearance.annotationStrokeColor else { return }
         
-        let currentLocation = gestureRecognizer.locationInView(annotationsView)
+        let currentLocation = gestureRecognizer.location(in: annotationsView)
         
-        let factory = AnnotationViewFactory(image: imageView.image?.CGImage, currentLocation: currentLocation, tool: currentTool, strokeColor: annotationStrokeColor)
+        let factory = AnnotationViewFactory(image: imageView.image?.cgImage, currentLocation: currentLocation, tool: currentTool, strokeColor: annotationStrokeColor)
         
         let view: AnnotationView = factory.annotationView()
         
         view.frame = annotationsView.bounds
-        view.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
+        view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         annotationsView.addSubview(view)
         currentAnnotationView = view
         beginEditingTextView()
     }
     
-    private func handleCreateAnnotationGestureRecognizerChanged(gestureRecognizer: UIPanGestureRecognizer) {
-        let currentLocation = gestureRecognizer.locationInView(annotationsView)
+    private func handleCreateAnnotationGestureRecognizerChanged(_ gestureRecognizer: UIPanGestureRecognizer) {
+        let currentLocation = gestureRecognizer.location(in: annotationsView)
         currentAnnotationView?.setSecondControlPoint(currentLocation)
     }
     
     // MARK: - Update annotations
     
-    @objc private func handleUpdateAnnotationGestureRecognizer(gestureRecognizer: UIPanGestureRecognizer) {
+    @objc private func handleUpdateAnnotationGestureRecognizer(_ gestureRecognizer: UIPanGestureRecognizer) {
         switch gestureRecognizer.state {
-        case .Began:
+        case .began:
             handleUpdateAnnotationGestureRecognizerBegan(gestureRecognizer)
-        case .Changed:
+        case .changed:
             handleUpdateAnnotationGestureRecognizerChanged(gestureRecognizer)
-        case .Cancelled, .Failed, .Ended:
+        case .cancelled, .failed, .ended:
             handleGestureRecognizerFinished()
         default:
             break
         }
     }
     
-    private func handleUpdateAnnotationGestureRecognizerBegan(gestureRecognizer: UIPanGestureRecognizer) {
+    private func handleUpdateAnnotationGestureRecognizerBegan(_ gestureRecognizer: UIPanGestureRecognizer) {
         currentAnnotationView = annotationViewWithGestureRecognizer(gestureRecognizer)
-        previousUpdateAnnotationPanGestureRecognizerLocation = gestureRecognizer.locationInView(gestureRecognizer.view)
+        previousUpdateAnnotationPanGestureRecognizerLocation = gestureRecognizer.location(in: gestureRecognizer.view)
         currentBlurAnnotationView?.drawsBorder = true
         
-        UIMenuController.sharedMenuController().setMenuVisible(false, animated: true)
+        UIMenuController.shared().setMenuVisible(false, animated: true)
         currentTextAnnotationView?.textView.selectedRange = NSRange()
     }
     
-    private func handleUpdateAnnotationGestureRecognizerChanged(gestureRecognizer: UIPanGestureRecognizer) {
-        let currentLocation = gestureRecognizer.locationInView(gestureRecognizer.view)
+    private func handleUpdateAnnotationGestureRecognizerChanged(_ gestureRecognizer: UIPanGestureRecognizer) {
+        let currentLocation = gestureRecognizer.location(in: gestureRecognizer.view)
         let previousLocation = previousUpdateAnnotationPanGestureRecognizerLocation
-        let offset = CGPoint(x: currentLocation.x - previousLocation.x, y: currentLocation.y - previousLocation.y)
+        let offset = CGPoint(x: currentLocation.x - (previousLocation?.x)!, y: currentLocation.y - (previousLocation?.y)!)
         currentAnnotationView?.moveControlPoints(offset)
-        previousUpdateAnnotationPanGestureRecognizerLocation = gestureRecognizer.locationInView(gestureRecognizer.view)
+        previousUpdateAnnotationPanGestureRecognizerLocation = gestureRecognizer.location(in: gestureRecognizer.view)
     }
     
-    @objc private func handleUpdateAnnotationTapGestureRecognizer(gestureRecognizer: UITapGestureRecognizer) {
+    @objc private func handleUpdateAnnotationTapGestureRecognizer(_ gestureRecognizer: UITapGestureRecognizer) {
         switch gestureRecognizer.state {
-        case .Ended:
+        case .ended:
             if let annotationView = annotationViewWithGestureRecognizer(gestureRecognizer) {
                 currentAnnotationView = annotationView as? TextAnnotationView
                 beginEditingTextView()
-            } else if currentTool == .Text {
+            } else if currentTool == .text {
                 handleCreateAnnotationGestureRecognizerBegan(gestureRecognizer)
             }
         default:
@@ -540,26 +540,26 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         }
     }
     
-    @objc private func handleUpdateAnnotationPinchGestureRecognizer(gestureRecognizer: UIPinchGestureRecognizer) {
+    @objc private func handleUpdateAnnotationPinchGestureRecognizer(_ gestureRecognizer: UIPinchGestureRecognizer) {
         switch gestureRecognizer.state {
-        case .Began:
+        case .began:
             handleUpdateAnnotationPinchGestureRecognizerBegan(gestureRecognizer)
-        case .Changed:
+        case .changed:
             handleUpdateAnnotationPinchGestureRecognizerChanged(gestureRecognizer)
-        case .Cancelled, .Failed, .Ended:
+        case .cancelled, .failed, .ended:
             handleGestureRecognizerFinished()
         default:
             break
         }
     }
     
-    private func handleUpdateAnnotationPinchGestureRecognizerBegan(gestureRecognizer: UIPinchGestureRecognizer) {
+    private func handleUpdateAnnotationPinchGestureRecognizerBegan(_ gestureRecognizer: UIPinchGestureRecognizer) {
         currentAnnotationView = annotationViewWithGestureRecognizer(gestureRecognizer)
         previousUpdateAnnotationPinchScale = 1
         currentBlurAnnotationView?.drawsBorder = true
     }
     
-    private func handleUpdateAnnotationPinchGestureRecognizerChanged(gestureRecognizer: UIPinchGestureRecognizer) {
+    private func handleUpdateAnnotationPinchGestureRecognizerChanged(_ gestureRecognizer: UIPinchGestureRecognizer) {
         if previousUpdateAnnotationPinchScale != 0 {
             currentAnnotationView?.scaleControlPoints(gestureRecognizer.scale / previousUpdateAnnotationPinchScale)
         }
@@ -569,14 +569,14 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
     
     // MARK: - Delete annotations
     
-    @objc private func handleDoubleTapGestureRecognizer(gestureRecognizer: UITapGestureRecognizer) {
+    @objc private func handleDoubleTapGestureRecognizer(_ gestureRecognizer: UITapGestureRecognizer) {
         if let view = annotationViewWithGestureRecognizer(gestureRecognizer) {
             deleteAnnotationView(view, animated: true)
         }
     }
     
-    @objc private func handleLongPressGestureRecognizer(gestureRecognizer: UILongPressGestureRecognizer) {
-        if gestureRecognizer.state != UIGestureRecognizerState.Began {
+    @objc private func handleLongPressGestureRecognizer(_ gestureRecognizer: UILongPressGestureRecognizer) {
+        if gestureRecognizer.state != UIGestureRecognizerState.began {
             return
         }
         
@@ -585,11 +585,11 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         selectedAnnotationView = view
         becomeFirstResponder()
         
-        let point = gestureRecognizer.locationInView(gestureRecognizer.view)
+        let point = gestureRecognizer.location(in: gestureRecognizer.view)
         let targetRect = CGRect(origin: point, size: CGSize())
         
-        let controller = UIMenuController.sharedMenuController()
-        controller.setTargetRect(targetRect, inView: view)
+        let controller = UIMenuController.shared()
+        controller.setTargetRect(targetRect, in: view)
         controller.menuItems = [
             UIMenuItem(title: "Delete", action: #selector(EditImageViewController.deleteSelectedAnnotationView))
         ]
@@ -597,14 +597,14 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         controller.setMenuVisible(true, animated: true)
     }
     
-    private func deleteAnnotationView(annotationView: UIView, animated: Bool) {
+    private func deleteAnnotationView(_ annotationView: UIView, animated: Bool) {
         let removeAnnotationView = {
             self.endEditingTextView()
             annotationView.removeFromSuperview()
         }
         
         if animated {
-            UIView.performSystemAnimation(.Delete, onViews: [annotationView], options: [], animations: nil) { finished in
+            UIView.perform(.delete, on: [annotationView], options: [], animations: nil) { finished in
                 removeAnnotationView()
             }
             
@@ -621,7 +621,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
     
     // MARK: - UIGestureRecognizerDelegate
     
-    public func gestureRecognizerShouldBegin(gestureRecognizer: UIGestureRecognizer) -> Bool {
+    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         if gestureRecognizer == createAnnotationPanGestureRecognizer {
             return annotationViewWithGestureRecognizer(gestureRecognizer) == nil
         }
@@ -632,7 +632,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         
         if gestureRecognizer == createOrUpdateAnnotationTapGestureRecognizer {
             let annotationViewExists = annotationViewWithGestureRecognizer(gestureRecognizer) != nil
-            return currentTool == .Text ? true : annotationViewExists
+            return currentTool == .text ? true : annotationViewExists
         }
         
         if gestureRecognizer == touchDownGestureRecognizer {
@@ -644,7 +644,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         return !isEditingText
     }
     
-    public func gestureRecognizer(gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWithGestureRecognizer otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         let isTouchDown = gestureRecognizer == touchDownGestureRecognizer || otherGestureRecognizer == touchDownGestureRecognizer
         let isPinch = gestureRecognizer == updateAnnotationPinchGestureRecognizer || otherGestureRecognizer == updateAnnotationPinchGestureRecognizer
         
@@ -653,7 +653,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
 }
 
 extension EditImageViewController: Editor {
-    public func setScreenshot(screenshot: UIImage) {
+    public func setScreenshot(_ screenshot: UIImage) {
         let oldScreenshot = imageView.image
         
         imageView.image = screenshot

--- a/PinpointKit/PinpointKit/Sources/Editing/Editor.swift
+++ b/PinpointKit/PinpointKit/Sources/Editing/Editor.swift
@@ -20,7 +20,7 @@ public protocol Editor: class, InterfaceCustomizable {
      
      - parameter screenshot: The screenshot to be edited.
      */
-    func setScreenshot(screenshot: UIImage)
+    func setScreenshot(_ screenshot: UIImage)
 }
 
 extension Editor where Self: UIViewController {

--- a/PinpointKit/PinpointKit/Sources/Editing/EditorDelegate.swift
+++ b/PinpointKit/PinpointKit/Sources/Editing/EditorDelegate.swift
@@ -15,7 +15,7 @@ public protocol EditorDelegate: class {
      - parameter editor: The editor resonsible for editing the image.
      - parameter screenshot: The edited image of a screenshot, after editing is complete.
      */
-    func editorWillDismiss(editor: Editor, screenshot: UIImage)
+    func editorWillDismiss(_ editor: Editor, screenshot: UIImage)
     
     /**
      A function that is called with an image to ask if the editor should be dismissed.
@@ -25,12 +25,12 @@ public protocol EditorDelegate: class {
     
     - returns: A bool value that defines if the editor dismisses or not.
      */
-    func editorShouldDismiss(editor: Editor, screenshot: UIImage) -> Bool
+    func editorShouldDismiss(_ editor: Editor, screenshot: UIImage) -> Bool
 }
 
 /// Extends editor delegate with base implementation for functions.
 extension EditorDelegate {
-    public func editorShouldDismiss(editor: Editor, screenshot: UIImage) -> Bool {
+    public func editorShouldDismiss(_ editor: Editor, screenshot: UIImage) -> Bool {
         return true
     }
 }

--- a/PinpointKit/PinpointKit/Sources/Editing/Tool.swift
+++ b/PinpointKit/PinpointKit/Sources/Editing/Tool.swift
@@ -12,45 +12,45 @@ import UIKit
 enum Tool: Int {
     
     /// The arrow tool.
-    case Arrow
+    case arrow
     
     /// The box tool.
-    case Box
+    case box
     
     /// The text tool.
-    case Text
+    case text
     
     /// The blur tool.
-    case Blur
+    case blur
     
     /// The name of the tool.
     var name: String {
         switch self {
-        case .Arrow:
+        case .arrow:
             return "Arrow Tool"
-        case .Box:
+        case .box:
             return "Box Tool"
-        case .Text:
+        case .text:
             return "Text Tool"
-        case .Blur:
+        case .blur:
             return "Blur Tool"
         }
     }
     
     /// The image for the tool.
     var image: UIImage {
-        let bundle = NSBundle.pinpointKitBundle()
+        let bundle = Bundle.pinpointKitBundle()
         
         func loadImage() -> UIImage? {
             switch self {
-            case .Arrow:
-                return UIImage(named: "ArrowIcon", inBundle: bundle, compatibleWithTraitCollection: nil)
-            case .Box:
-                return UIImage(named: "BoxIcon", inBundle: bundle, compatibleWithTraitCollection: nil)
-            case .Text:
+            case .arrow:
+                return UIImage(named: "ArrowIcon", in: bundle, compatibleWith: nil)
+            case .box:
+                return UIImage(named: "BoxIcon", in: bundle, compatibleWith: nil)
+            case .text:
                 return UIImage()
-            case .Blur:
-                return UIImage(named: "BlurIcon", inBundle: bundle, compatibleWithTraitCollection: nil)
+            case .blur:
+                return UIImage(named: "BlurIcon", in: bundle, compatibleWith: nil)
             }
         }
         
@@ -60,11 +60,11 @@ enum Tool: Int {
     /// The item to use for a segmented control.
     var segmentedControlItem: AnyObject {
         switch self {
-        case .Arrow, .Box, .Blur:
+        case .arrow, .box, .blur:
             let image = self.image
             image.accessibilityLabel = self.name
             return image
-        case .Text:
+        case .text:
             return NSLocalizedString("Aa", comment: "The text tool’s button label.")
         }
     }

--- a/PinpointKit/PinpointKit/Sources/Feedback.swift
+++ b/PinpointKit/PinpointKit/Sources/Feedback.swift
@@ -14,22 +14,22 @@ public struct Feedback {
     /// An enum with assocated values that represents the screenshot.
     enum ScreenshotType {
         /// The original, un-annotated screenshot.
-        case Original(image: UIImage)
+        case original(image: UIImage)
         
         /// An annotated screenshot.
-        case Annotated(image: UIImage)
+        case annotated(image: UIImage)
         
         /// Both the original and annotated screenshot.
-        case Combined(originalImage: UIImage, annotatedImage: UIImage)
+        case combined(originalImage: UIImage, annotatedImage: UIImage)
         
         /// Returns an image of the screenshot preferring the annotated image.
         var preferredImage: UIImage {
             switch self {
-            case let Original(image):
+            case let original(image):
                 return image
-            case let Annotated(image):
+            case let annotated(image):
                 return image
-            case let Combined(_, annotatedImage):
+            case let combined(_, annotatedImage):
                 return annotatedImage
             }
         }
@@ -50,7 +50,7 @@ public struct Feedback {
         let bundleIdentifer: String?
         
         /// The operating system version of the OS in which the application is running.
-        let operatingSystemVersion: NSOperatingSystemVersion?
+        let operatingSystemVersion: OperatingSystemVersion?
     }
     
     /// A screenshot of the screen the feedback relates to.

--- a/PinpointKit/PinpointKit/Sources/FeedbackCollector.swift
+++ b/PinpointKit/PinpointKit/Sources/FeedbackCollector.swift
@@ -27,7 +27,7 @@ public protocol FeedbackCollector: class, LogSupporting, InterfaceCustomizable {
      - parameter screenshot:     The screenshot the user will be providing feedback on.
      - parameter viewController: The view controller from which to present.
      */
-    func collectFeedbackWithScreenshot(screenshot: UIImage, fromViewController viewController: UIViewController)
+    func collectFeedbackWithScreenshot(_ screenshot: UIImage, fromViewController viewController: UIViewController)
 }
 
 extension FeedbackCollector where Self: UIViewController {
@@ -45,5 +45,5 @@ public protocol FeedbackCollectorDelegate: class {
      - parameter feedbackCollector: The collector which collected the feedback.
      - parameter feedback:          The feedback that was collected by the collector.
      */
-    func feedbackCollector(feedbackCollector: FeedbackCollector, didCollectFeedback feedback: Feedback)
+    func feedbackCollector(_ feedbackCollector: FeedbackCollector, didCollectFeedback feedback: Feedback)
 }

--- a/PinpointKit/PinpointKit/Sources/FeedbackNavigationController.swift
+++ b/PinpointKit/PinpointKit/Sources/FeedbackNavigationController.swift
@@ -90,7 +90,7 @@ public final class FeedbackNavigationController: UINavigationController, Feedbac
     }
     
     @available(*, unavailable)
-    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         feedbackViewController = FeedbackViewController()
         
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
@@ -114,7 +114,7 @@ public final class FeedbackNavigationController: UINavigationController, Feedbac
 
     // MARK: - FeedbackCollector
     
-    public func collectFeedbackWithScreenshot(screenshot: UIImage, fromViewController viewController: UIViewController) {
+    public func collectFeedbackWithScreenshot(_ screenshot: UIImage, fromViewController viewController: UIViewController) {
         guard presentingViewController == nil else {
             NSLog("Unable to present FeedbackNavigationController because it is already being presetned")
             return
@@ -123,6 +123,6 @@ public final class FeedbackNavigationController: UINavigationController, Feedbac
         feedbackViewController.screenshot = screenshot
         feedbackViewController.annotatedScreenshot = screenshot
 
-        viewController.presentViewController(self, animated: true, completion: nil)
+        viewController.present(self, animated: true, completion: nil)
     }
 }

--- a/PinpointKit/PinpointKit/Sources/FeedbackTableViewDataSource.swift
+++ b/PinpointKit/PinpointKit/Sources/FeedbackTableViewDataSource.swift
@@ -25,54 +25,54 @@ final class FeedbackTableViewDataSource: NSObject, UITableViewDataSource {
     }
     
     private enum Section {
-        case Feedback(rows: [Row])
+        case feedback(rows: [Row])
         
         var numberOfRows: Int {
             switch self {
-            case let .Feedback(rows):
+            case let .feedback(rows):
                 return rows.count
             }
         }
     }
     
     private enum Row {
-        case CollectLogs(enabled: Bool, title: String, font: UIFont, canView: Bool)
+        case collectLogs(enabled: Bool, title: String, font: UIFont, canView: Bool)
     }
     
     // MARK: - FeedbackTableViewDataSource
     
-    private static func sectionsFromConfiguration(interfaceCustomization: InterfaceCustomization, logSupporting: LogSupporting, userEnabledLogCollection: Bool) -> [Section] {
+    private static func sectionsFromConfiguration(_ interfaceCustomization: InterfaceCustomization, logSupporting: LogSupporting, userEnabledLogCollection: Bool) -> [Section] {
         guard logSupporting.logCollector != nil else { return [] }
         
-        let collectLogsRow = Row.CollectLogs(enabled: userEnabledLogCollection, title: interfaceCustomization.interfaceText.logCollectionPermissionTitle, font: interfaceCustomization.appearance.logCollectionPermissionFont, canView: logSupporting.logViewer != nil)
-        let feedbackSection = Section.Feedback(rows: [collectLogsRow])
+        let collectLogsRow = Row.collectLogs(enabled: userEnabledLogCollection, title: interfaceCustomization.interfaceText.logCollectionPermissionTitle, font: interfaceCustomization.appearance.logCollectionPermissionFont, canView: logSupporting.logViewer != nil)
+        let feedbackSection = Section.feedback(rows: [collectLogsRow])
         
         return [feedbackSection]
     }
     
     // MARK: - UITableViewDataSource
     
-    func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return sections[section].numberOfRows
     }
     
-    func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+    func numberOfSections(in tableView: UITableView) -> Int {
         return sections.count
     }
     
-    func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = CheckmarkCell()
-        let section = sections[indexPath.section]
+        let section = sections[(indexPath as NSIndexPath).section]
         
         switch section {
-        case let .Feedback(rows):
-            let row = rows[indexPath.row]
+        case let .feedback(rows):
+            let row = rows[(indexPath as NSIndexPath).row]
             
             switch row {
-            case let .CollectLogs(enabled, title, font, canView):
+            case let .collectLogs(enabled, title, font, canView):
                 cell.textLabel?.text = title
                 cell.textLabel?.font = font
-                cell.accessoryType = canView ? .DetailButton : .None
+                cell.accessoryType = canView ? .detailButton : .none
                 cell.isChecked = enabled
             }
         }

--- a/PinpointKit/PinpointKit/Sources/FeedbackViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/FeedbackViewController.swift
@@ -64,12 +64,12 @@ public final class FeedbackViewController: UITableViewController {
     }
     
     public required init() {
-        super.init(style: .Grouped)
+        super.init(style: .grouped)
     }
     
     @available(*, unavailable)
     override init(style: UITableViewStyle) {
-        super.init(style: .Grouped)
+        super.init(style: .grouped)
     }
     
     @available(*, unavailable)
@@ -85,16 +85,16 @@ public final class FeedbackViewController: UITableViewController {
         updateInterfaceCustomization()
     }
     
-    public override func viewWillAppear(animated: Bool) {
+    public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
         // Since this view controller could be reused in another orientation, update the table header view on every appearance to reflect the current orientation sizing.
         updateTableHeaderView()
     }
     
-    public override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
+    public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         
-        coordinator.animateAlongsideTransition({ context in
+        coordinator.animate(alongsideTransition: { context in
             // Layout and adjust the height of the table header view by setting the property once more to alert the table view of a layout change.
             self.tableView.tableHeaderView?.layoutIfNeeded()
             self.tableView.tableHeaderView = self.tableView.tableHeaderView
@@ -121,7 +121,7 @@ public final class FeedbackViewController: UITableViewController {
         header.screenshotButtonTapHandler = { [weak self] button in
             let editImageViewController = NavigationController(rootViewController: editor.viewController)
             editImageViewController.view.tintColor = self?.interfaceCustomization?.appearance.tintColor
-            self?.presentViewController(editImageViewController, animated: true, completion: nil)
+            self?.present(editImageViewController, animated: true, completion: nil)
         }
         
         tableView.tableHeaderView = header
@@ -136,23 +136,23 @@ public final class FeedbackViewController: UITableViewController {
         title = interfaceText.feedbackCollectorTitle
         navigationController?.navigationBar.titleTextAttributes = [NSFontAttributeName: appearance.navigationTitleFont]
         
-        let sendBarButtonItem = UIBarButtonItem(title: interfaceText.feedbackSendButtonTitle, style: .Done, target: self, action: #selector(FeedbackViewController.sendButtonTapped))
-        sendBarButtonItem.setTitleTextAttributes([NSFontAttributeName: appearance.feedbackSendButtonFont], forState: .Normal)
+        let sendBarButtonItem = UIBarButtonItem(title: interfaceText.feedbackSendButtonTitle, style: .done, target: self, action: #selector(FeedbackViewController.sendButtonTapped))
+        sendBarButtonItem.setTitleTextAttributes([NSFontAttributeName: appearance.feedbackSendButtonFont], for: UIControlState())
         navigationItem.rightBarButtonItem = sendBarButtonItem
         
-        let backBarButtonItem = UIBarButtonItem(title: interfaceText.feedbackBackButtonTitle, style: .Plain, target: nil, action: nil)
-        backBarButtonItem.setTitleTextAttributes([NSFontAttributeName: appearance.feedbackBackButtonFont], forState: .Normal)
+        let backBarButtonItem = UIBarButtonItem(title: interfaceText.feedbackBackButtonTitle, style: .plain, target: nil, action: nil)
+        backBarButtonItem.setTitleTextAttributes([NSFontAttributeName: appearance.feedbackBackButtonFont], for: UIControlState())
         navigationItem.backBarButtonItem = backBarButtonItem
         
         let cancelBarButtonItem: UIBarButtonItem
         let cancelAction = #selector(FeedbackViewController.cancelButtonTapped)
         if let cancelButtonTitle = interfaceText.feedbackCancelButtonTitle {
-            cancelBarButtonItem = UIBarButtonItem(title: cancelButtonTitle, style: .Plain, target: self, action: cancelAction)
+            cancelBarButtonItem = UIBarButtonItem(title: cancelButtonTitle, style: .plain, target: self, action: cancelAction)
         } else {
-            cancelBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Cancel, target: self, action: cancelAction)
+            cancelBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: cancelAction)
         }
         
-        cancelBarButtonItem.setTitleTextAttributes([NSFontAttributeName: appearance.feedbackCancelButtonFont], forState: .Normal)
+        cancelBarButtonItem.setTitleTextAttributes([NSFontAttributeName: appearance.feedbackCancelButtonFont], for: UIControlState())
         navigationItem.leftBarButtonItem = cancelBarButtonItem
         
         view.tintColor = appearance.tintColor
@@ -167,9 +167,9 @@ public final class FeedbackViewController: UITableViewController {
         let feedback: Feedback?
         
         if let screenshot = annotatedScreenshot {
-            feedback = Feedback(screenshot: .Annotated(image: screenshot), recipients: feedbackRecipients, logs: logs)
+            feedback = Feedback(screenshot: .annotated(image: screenshot), recipients: feedbackRecipients, logs: logs)
         } else if let screenshot = screenshot {
-            feedback = Feedback(screenshot: .Original(image: screenshot), recipients: feedbackRecipients, logs: logs)
+            feedback = Feedback(screenshot: .original(image: screenshot), recipients: feedbackRecipients, logs: logs)
         } else {
             feedback = nil
         }
@@ -180,14 +180,14 @@ public final class FeedbackViewController: UITableViewController {
     }
     
     @objc private func cancelButtonTapped() {        
-        dismissViewControllerAnimated(true, completion: nil)
+        dismiss(animated: true, completion: nil)
     }
 }
 
 // MARK: - FeedbackCollector
 
 extension FeedbackViewController: FeedbackCollector {
-    public func collectFeedbackWithScreenshot(screenshot: UIImage, fromViewController viewController: UIViewController) {
+    public func collectFeedbackWithScreenshot(_ screenshot: UIImage, fromViewController viewController: UIViewController) {
         self.screenshot = screenshot
         annotatedScreenshot = nil
         viewController.showDetailViewController(self, sender: viewController)
@@ -197,7 +197,7 @@ extension FeedbackViewController: FeedbackCollector {
 // MARK: - EditorDelegate
 
 extension FeedbackViewController: EditorDelegate {
-    public func editorWillDismiss(editor: Editor, screenshot: UIImage) {
+    public func editorWillDismiss(_ editor: Editor, screenshot: UIImage) {
         annotatedScreenshot = screenshot
         updateTableHeaderView()
     }
@@ -206,7 +206,7 @@ extension FeedbackViewController: EditorDelegate {
 // MARK: - UITableViewDelegate
 
 extension FeedbackViewController {
-    public override func tableView(tableView: UITableView, accessoryButtonTappedForRowWithIndexPath indexPath: NSIndexPath) {
+    public override func tableView(_ tableView: UITableView, accessoryButtonTappedForRowWith indexPath: IndexPath) {
         guard let logCollector = logCollector else {
             assertionFailure("No log collector exists.")
             return
@@ -215,9 +215,9 @@ extension FeedbackViewController {
         logViewer?.viewLog(logCollector, fromViewController: self)
     }
     
-    public override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+    public override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         userEnabledLogCollection = !userEnabledLogCollection
-        tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
+        tableView.reloadRows(at: [indexPath], with: .automatic)
     }
 }
 
@@ -230,12 +230,12 @@ private extension UITableView {
         tableHeaderView?.translatesAutoresizingMaskIntoConstraints = false
         
         if let headerView = tableHeaderView {
-            let leadingConstraint = headerView.leadingAnchor.constraintEqualToAnchor(leadingAnchor)
-            let trailingContraint = headerView.trailingAnchor.constraintEqualToAnchor(trailingAnchor)
-            let topConstraint = headerView.topAnchor.constraintEqualToAnchor(topAnchor)
-            let widthConstraint = headerView.widthAnchor.constraintEqualToAnchor(widthAnchor)
+            let leadingConstraint = headerView.leadingAnchor.constraint(equalTo: leadingAnchor)
+            let trailingContraint = headerView.trailingAnchor.constraint(equalTo: trailingAnchor)
+            let topConstraint = headerView.topAnchor.constraint(equalTo: topAnchor)
+            let widthConstraint = headerView.widthAnchor.constraint(equalTo: widthAnchor)
             
-            NSLayoutConstraint.activateConstraints([leadingConstraint, trailingContraint, topConstraint, widthConstraint])
+            NSLayoutConstraint.activate([leadingConstraint, trailingContraint, topConstraint, widthConstraint])
             
             headerView.layoutIfNeeded()
             tableHeaderView = headerView

--- a/PinpointKit/PinpointKit/Sources/Fonts.swift
+++ b/PinpointKit/PinpointKit/Sources/Fonts.swift
@@ -13,13 +13,13 @@ import UIKit
 public enum FontWeight: Int {
     
     /// Regular weight.
-    case Regular
+    case regular
     
     /// Semibold weight.
-    case Semibold
+    case semibold
     
     /// Bold weight.
-    case Bold
+    case bold
 }
 
 public extension UIFont {
@@ -32,23 +32,23 @@ public extension UIFont {
      
      - returns: A Source Sans Pro `UIFont` at the specified size and weight.
      */
-    public static func sourceSansProFontOfSize(fontSize: CGFloat, weight: FontWeight = .Regular) -> UIFont {
+    public static func sourceSansProFontOfSize(_ fontSize: CGFloat, weight: FontWeight = .regular) -> UIFont {
         let fontName: String = {
             switch weight {
-            case .Regular:
+            case .regular:
                 return "SourceSansPro-Regular"
-            case .Semibold:
+            case .semibold:
                 return "SourceSansPro-Semibold"
-            case .Bold:
+            case .bold:
                 return "SourceSansPro-Bold"
             }
         }()
         
-        if let fontURL = NSBundle.pinpointKitBundle().URLForResource(fontName, withExtension: "ttf") {
-            CTFontManagerRegisterFontsForURL(fontURL, .Process, nil)
+        if let fontURL = Bundle.pinpointKitBundle().urlForResource(fontName, withExtension: "ttf") {
+            CTFontManagerRegisterFontsForURL(fontURL, .process, nil)
         }
         
-        return UIFont(name: fontName, size: fontSize) ?? UIFont.systemFontOfSize(fontSize)
+        return UIFont(name: fontName, size: fontSize) ?? UIFont.systemFont(ofSize: fontSize)
     }
     
     /**
@@ -58,7 +58,7 @@ public extension UIFont {
      
      - returns: A `UIFont` representing Menlo Regular at the specified size.
      */
-    public static func menloRegularFontOfSize(fontSize: CGFloat) -> UIFont {
-        return UIFont(name: "Menlo-Regular", size: fontSize) ?? UIFont.systemFontOfSize(fontSize)
+    public static func menloRegularFontOfSize(_ fontSize: CGFloat) -> UIFont {
+        return UIFont(name: "Menlo-Regular", size: fontSize) ?? UIFont.systemFont(ofSize: fontSize)
     }
 }

--- a/PinpointKit/PinpointKit/Sources/InterfaceCustomization.swift
+++ b/PinpointKit/PinpointKit/Sources/InterfaceCustomization.swift
@@ -85,17 +85,17 @@ public struct InterfaceCustomization {
          */
         public init(tintColor: UIColor? = UIColor.pinpointOrangeColor(),
                     annotationFillColor: UIColor? = nil,
-                    annotationStrokeColor: UIColor = .whiteColor(),
-                    navigationTitleFont: UIFont = .sourceSansProFontOfSize(19, weight: .Semibold),
-                    feedbackSendButtonFont: UIFont = .sourceSansProFontOfSize(19, weight: .Semibold),
+                    annotationStrokeColor: UIColor = .white(),
+                    navigationTitleFont: UIFont = .sourceSansProFontOfSize(19, weight: .semibold),
+                    feedbackSendButtonFont: UIFont = .sourceSansProFontOfSize(19, weight: .semibold),
                     feedbackCancelButtonFont: UIFont = .sourceSansProFontOfSize(19),
                     feedbackEditHintFont: UIFont = .sourceSansProFontOfSize(14),
                     feedbackBackButtonFont: UIFont = .sourceSansProFontOfSize(19),
                     logCollectionPermissionFont: UIFont = .sourceSansProFontOfSize(19),
                     logFont: UIFont = .menloRegularFontOfSize(10),
                     editorTextAnnotationSegmentFont: UIFont = .sourceSansProFontOfSize(18),
-                    editorTextAnnotationFont: UIFont = .sourceSansProFontOfSize(32, weight: .Semibold),
-                    editorTextAnnotationDoneButtonFont: UIFont = .sourceSansProFontOfSize(19, weight: .Semibold)) {
+                    editorTextAnnotationFont: UIFont = .sourceSansProFontOfSize(32, weight: .semibold),
+                    editorTextAnnotationDoneButtonFont: UIFont = .sourceSansProFontOfSize(19, weight: .semibold)) {
             self.tintColor = tintColor
             self.annotationFillColor = annotationFillColor
             self.annotationStrokeColor = annotationStrokeColor

--- a/PinpointKit/PinpointKit/Sources/LogViewer.swift
+++ b/PinpointKit/PinpointKit/Sources/LogViewer.swift
@@ -15,5 +15,5 @@ public protocol LogViewer: InterfaceCustomizable {
      - parameter collector:      The collector which has the logs to view.
      - parameter viewController: A view controller from which to present an interface for log viewing.
      */
-    func viewLog(collector: LogCollector, fromViewController viewController: UIViewController)
+    func viewLog(_ collector: LogCollector, fromViewController viewController: UIViewController)
 }

--- a/PinpointKit/PinpointKit/Sources/MailSender.swift
+++ b/PinpointKit/PinpointKit/Sources/MailSender.swift
@@ -158,16 +158,14 @@ extension MailSender: MFMailComposeViewControllerDelegate {
     
     private func completeWithResult(_ result: MFMailComposeResult, error: NSError?) {
         switch result {
-        case MFMailComposeResult.cancelled:
+        case .cancelled:
             fail(.mailCanceled(underlyingError: error))
-        case MFMailComposeResult.failed:
+        case .failed:
             fail(.mailFailed(underlyingError: error))
-        case MFMailComposeResult.saved:
+        case .saved:
             succeed(.saved)
-        case MFMailComposeResult.sent:
+        case .sent:
             succeed(.sent)
-        default:
-            fail(.unknown)
         }
     }
 }

--- a/PinpointKit/PinpointKit/Sources/MailSender.swift
+++ b/PinpointKit/PinpointKit/Sources/MailSender.swift
@@ -70,7 +70,7 @@ public class MailSender: NSObject, Sender {
         self.feedback = feedback
         
         do {
-            try mailComposer.attachFeedback(feedback)
+            try mailComposer.attach(feedback)
         } catch let error as Error {
             fail(error)
         } catch {
@@ -95,7 +95,7 @@ public class MailSender: NSObject, Sender {
 
 private extension MFMailComposeViewController {
     
-    func attachFeedback(_ feedback: Feedback) throws {
+    func attach(_ feedback: Feedback) throws {
         setToRecipients(feedback.recipients)
         
         if let subject = feedback.title {

--- a/PinpointKit/PinpointKit/Sources/MailSender.swift
+++ b/PinpointKit/PinpointKit/Sources/MailSender.swift
@@ -70,7 +70,7 @@ public class MailSender: NSObject, Sender {
         self.feedback = feedback
         
         do {
-            try mailComposer.attach(feedback)
+            try mailComposer.attachFeedback(feedback)
         } catch let error as Error {
             fail(error)
         } catch {
@@ -95,7 +95,7 @@ public class MailSender: NSObject, Sender {
 
 private extension MFMailComposeViewController {
     
-    func attach(_ feedback: Feedback) throws {
+    func attachFeedback(_ feedback: Feedback) throws {
         setToRecipients(feedback.recipients)
         
         if let subject = feedback.title {

--- a/PinpointKit/PinpointKit/Sources/MailSender.swift
+++ b/PinpointKit/PinpointKit/Sources/MailSender.swift
@@ -12,38 +12,38 @@ import MessageUI
 public class MailSender: NSObject, Sender {
 
     /// An error in sending feedback.
-    enum Error: ErrorType {
+    enum Error: ErrorProtocol {
 
         /// An unknown error occured.
-        case Unknown
+        case unknown
 
         /// No view controller was provided for presentation.
-        case NoViewControllerProvided
+        case noViewControllerProvided
         
         /// The screenshot failed to encode.
-        case ImageEncoding
+        case imageEncoding
         
         /// The text failed to encode.
-        case TextEncoding
+        case textEncoding
         
         /// `MFMailComposeViewController.canSendMail()` returned `false`.
-        case MailCannotSend
+        case mailCannotSend
         
         /// Email composing was canceled by the user.
-        case MailCanceled(underlyingError: NSError?)
+        case mailCanceled(underlyingError: NSError?)
         
         /// Email sending failed.
-        case MailFailed(underlyingError: NSError?)
+        case mailFailed(underlyingError: NSError?)
     }
     
     /// A success in sending feedback.
     enum Success: SuccessType {
         
         /// The email was saved as a draft.
-        case Saved
+        case saved
         
         /// The email was sent.
-        case Sent
+        case sent
     }
     
     private var feedback: Feedback?
@@ -59,10 +59,10 @@ public class MailSender: NSObject, Sender {
      - parameter feedback:       The feedback to send.
      - parameter viewController: The view controller from which to present any of the sender’s necessary views.
      */
-    public func sendFeedback(feedback: Feedback, fromViewController viewController: UIViewController?) {
-        guard let viewController = viewController else { fail(.NoViewControllerProvided); return }
+    public func sendFeedback(_ feedback: Feedback, fromViewController viewController: UIViewController?) {
+        guard let viewController = viewController else { fail(.noViewControllerProvided); return }
         
-        guard MFMailComposeViewController.canSendMail() else { fail(.MailCannotSend); return }
+        guard MFMailComposeViewController.canSendMail() else { fail(.mailCannotSend); return }
         
         let mailComposer = MFMailComposeViewController()
         mailComposer.mailComposeDelegate = self
@@ -74,20 +74,20 @@ public class MailSender: NSObject, Sender {
         } catch let error as Error {
             fail(error)
         } catch {
-            fail(.Unknown)
+            fail(.unknown)
         }
         
-        viewController.presentViewController(mailComposer, animated: true, completion: nil)
+        viewController.present(mailComposer, animated: true, completion: nil)
     }
     
     // MARK: - MailSender
     
-    private func fail(error: Error) {
+    private func fail(_ error: Error) {
         delegate?.sender(self, didFailToSendFeedback: feedback, error: error)
         feedback = nil
     }
     
-    private func succeed(success: Success) {
+    private func succeed(_ success: Success) {
         delegate?.sender(self, didSendFeedback: feedback, success: success)
         feedback = nil
     }
@@ -95,7 +95,7 @@ public class MailSender: NSObject, Sender {
 
 private extension MFMailComposeViewController {
     
-    func attachFeedback(feedback: Feedback) throws {
+    func attachFeedback(_ feedback: Feedback) throws {
         setToRecipients(feedback.recipients)
         
         if let subject = feedback.title {
@@ -117,29 +117,29 @@ private extension MFMailComposeViewController {
         }
     }
     
-    func attachScreenshot(screenshot: Feedback.ScreenshotType, screenshotFileName: String) throws {
+    func attachScreenshot(_ screenshot: Feedback.ScreenshotType, screenshotFileName: String) throws {
         try attachImage(screenshot.preferredImage, filename: screenshotFileName + MIMEType.PNG.fileExtension)
     }
     
-    func attachLogs(logs: [String], logsFileName: String) throws {
-        let logsText = logs.joinWithSeparator("\n\n")
+    func attachLogs(_ logs: [String], logsFileName: String) throws {
+        let logsText = logs.joined(separator: "\n\n")
         try attachText(logsText, filename: logsFileName + MIMEType.PlainText.fileExtension)
     }
     
-    func attachImage(image: UIImage, filename: String) throws {
-        guard let PNGData = UIImagePNGRepresentation(image) else { throw MailSender.Error.ImageEncoding }
+    func attachImage(_ image: UIImage, filename: String) throws {
+        guard let PNGData = UIImagePNGRepresentation(image) else { throw MailSender.Error.imageEncoding }
         
         addAttachmentData(PNGData, mimeType: MIMEType.PNG.rawValue, fileName: filename)
     }
     
-    func attachText(text: String, filename: String) throws {
-        guard let textData = text.dataUsingEncoding(NSUTF8StringEncoding) else { throw MailSender.Error.TextEncoding }
+    func attachText(_ text: String, filename: String) throws {
+        guard let textData = text.data(using: String.Encoding.utf8) else { throw MailSender.Error.textEncoding }
         
         addAttachmentData(textData, mimeType: MIMEType.PlainText.rawValue, fileName: filename)
     }
     
-    func attachAdditionalInformation(additionalInformation: [String: AnyObject]) {
-        let data = try? NSJSONSerialization.dataWithJSONObject(additionalInformation, options: .PrettyPrinted)
+    func attachAdditionalInformation(_ additionalInformation: [String: AnyObject]) {
+        let data = try? JSONSerialization.data(withJSONObject: additionalInformation, options: .prettyPrinted)
         
         if let data = data {
             addAttachmentData(data, mimeType: MIMEType.JSON.rawValue, fileName: "info.json")
@@ -150,24 +150,24 @@ private extension MFMailComposeViewController {
 }
 
 extension MailSender: MFMailComposeViewControllerDelegate {
-    public func mailComposeController(controller: MFMailComposeViewController, didFinishWithResult result: MFMailComposeResult, error: NSError?) {
-        controller.dismissViewControllerAnimated(true) {
+    public func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: NSError?) {
+        controller.dismiss(animated: true) {
             self.completeWithResult(result, error: error)
         }
     }
     
-    private func completeWithResult(result: MFMailComposeResult, error: NSError?) {
+    private func completeWithResult(_ result: MFMailComposeResult, error: NSError?) {
         switch result {
-        case MFMailComposeResultCancelled:
-            fail(.MailCanceled(underlyingError: error))
-        case MFMailComposeResultFailed:
-            fail(.MailFailed(underlyingError: error))
-        case MFMailComposeResultSaved:
-            succeed(.Saved)
-        case MFMailComposeResultSent:
-            succeed(.Sent)
+        case MFMailComposeResult.cancelled:
+            fail(.mailCanceled(underlyingError: error))
+        case MFMailComposeResult.failed:
+            fail(.mailFailed(underlyingError: error))
+        case MFMailComposeResult.saved:
+            succeed(.saved)
+        case MFMailComposeResult.sent:
+            succeed(.sent)
         default:
-            fail(.Unknown)
+            fail(.unknown)
         }
     }
 }

--- a/PinpointKit/PinpointKit/Sources/NSBundle+PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/NSBundle+PinpointKit.swift
@@ -9,14 +9,14 @@
 import Foundation
 
 /// Extends `NSBundle` to provide bundles from PinpointKit.
-extension NSBundle {
+extension Bundle {
     
     /**
      The main PinpointKit bundle.
      
      - returns: Returns the bundle associated with PinpointKit.
      */
-    static func pinpointKitBundle() -> NSBundle {
-        return NSBundle(forClass: PinpointKit.self)
+    static func pinpointKitBundle() -> Bundle {
+        return Bundle(for: PinpointKit.self)
     }
 }

--- a/PinpointKit/PinpointKit/Sources/NavigationController.swift
+++ b/PinpointKit/PinpointKit/Sources/NavigationController.swift
@@ -13,7 +13,7 @@ final class NavigationController: UINavigationController, UINavigationController
 
     // MARK: - Initializers
 
-    override init(nibName: String?, bundle nibBundle: NSBundle?) {
+    override init(nibName: String?, bundle nibBundle: Bundle?) {
         super.init(nibName: nibName, bundle: nibBundle)
         delegate = self
     }
@@ -21,7 +21,7 @@ final class NavigationController: UINavigationController, UINavigationController
     override init(rootViewController: UIViewController) {
         super.init(rootViewController: rootViewController)
         delegate = self
-        modalPresentationStyle = .FullScreen // Necessary for proper transition rotation.
+        modalPresentationStyle = .fullScreen // Necessary for proper transition rotation.
         modalPresentationCapturesStatusBarAppearance = true
     }
 
@@ -37,11 +37,11 @@ final class NavigationController: UINavigationController, UINavigationController
     }
     
     override func supportedInterfaceOrientations() -> UIInterfaceOrientationMask {
-        return topViewController?.supportedInterfaceOrientations() ?? .All
+        return topViewController?.supportedInterfaceOrientations() ?? .all
     }
     
     override func preferredInterfaceOrientationForPresentation() -> UIInterfaceOrientation {
-        return topViewController?.preferredInterfaceOrientationForPresentation() ?? .Unknown
+        return topViewController?.preferredInterfaceOrientationForPresentation() ?? .unknown
     }
     
     override func childViewControllerForStatusBarHidden() -> UIViewController? {

--- a/PinpointKit/PinpointKit/Sources/PinpointKit+ShakePresentation.swift
+++ b/PinpointKit/PinpointKit/Sources/PinpointKit+ShakePresentation.swift
@@ -14,7 +14,7 @@ extension PinpointKit: ShakeDetectingWindowDelegate {
     
     // MARK: - ShakeDetectingWindowDelegate
     
-    public func shakeDetectingWindowDidDetectShake(shakeDetectingWindow: ShakeDetectingWindow) {
+    public func shakeDetectingWindowDidDetectShake(_ shakeDetectingWindow: ShakeDetectingWindow) {
         guard let viewController = shakeDetectingWindow.rootViewController?.pinpointTopModalViewController() else {
             NSLog("PinpointPresentingShakeDetectingWindowDelegate couldn't find a root view controller to present on.")
             return

--- a/PinpointKit/PinpointKit/Sources/PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/PinpointKit.swift
@@ -54,7 +54,7 @@ public class PinpointKit {
 
 extension PinpointKit: FeedbackCollectorDelegate {
     
-    public func feedbackCollector(feedbackCollector: FeedbackCollector, didCollectFeedback feedback: Feedback) {
+    public func feedbackCollector(_ feedbackCollector: FeedbackCollector, didCollectFeedback feedback: Feedback) {
         delegate?.pinpointKit(self, willSendFeedback: feedback)
         configuration.sender.sendFeedback(feedback, fromViewController: feedbackCollector.viewController)
     }
@@ -64,15 +64,15 @@ extension PinpointKit: FeedbackCollectorDelegate {
 
 extension PinpointKit: SenderDelegate {
     
-    public func sender(sender: Sender, didSendFeedback feedback: Feedback?, success: SuccessType?) {
+    public func sender(_ sender: Sender, didSendFeedback feedback: Feedback?, success: SuccessType?) {
         guard let feedback = feedback else { return }
         
         delegate?.pinpointKit(self, didSendFeedback: feedback)
-        displayingViewController?.dismissViewControllerAnimated(true, completion: nil)
+        displayingViewController?.dismiss(animated: true, completion: nil)
     }
     
-    public func sender(sender: Sender, didFailToSendFeedback feedback: Feedback?, error: ErrorType) {
-        if case MailSender.Error.MailCanceled = error { return }
+    public func sender(_ sender: Sender, didFailToSendFeedback feedback: Feedback?, error: ErrorProtocol) {
+        if case MailSender.Error.mailCanceled = error { return }
         
         NSLog("An error occurred sending mail: \(error)")
     }
@@ -87,7 +87,7 @@ public protocol PinpointKitDelegate: class {
      - parameter pinpointKit:   The `PinpointKit` instance responsible for the feedback.
      - parameter feedback:      The feedback that’s about to be sent.
      */
-    func pinpointKit(pinpointKit: PinpointKit, willSendFeedback feedback: Feedback)
+    func pinpointKit(_ pinpointKit: PinpointKit, willSendFeedback feedback: Feedback)
     
     /**
      Notifies the delegate that PinpointKit has just sent user feedback.
@@ -95,12 +95,12 @@ public protocol PinpointKitDelegate: class {
      - parameter pinpointKit:   The `PinpointKit` instance responsible for the feedback.
      - parameter feedback:      The feedback that’s just been sent.
      */
-    func pinpointKit(pinpointKit: PinpointKit, didSendFeedback feedback: Feedback)
+    func pinpointKit(_ pinpointKit: PinpointKit, didSendFeedback feedback: Feedback)
 }
 
 /// An extension on PinpointKitDelegate that makes all delegate methods optional by giving them empty implementations by default.
 public extension PinpointKitDelegate {
     
-    func pinpointKit(pinpointKit: PinpointKit, willSendFeedback feedback: Feedback) {}
-    func pinpointKit(pinpointKit: PinpointKit, didSendFeedback feedback: Feedback) {}
+    func pinpointKit(_ pinpointKit: PinpointKit, willSendFeedback feedback: Feedback) {}
+    func pinpointKit(_ pinpointKit: PinpointKit, didSendFeedback feedback: Feedback) {}
 }

--- a/PinpointKit/PinpointKit/Sources/ScreenshotDetector.swift
+++ b/PinpointKit/PinpointKit/Sources/ScreenshotDetector.swift
@@ -131,7 +131,7 @@ private extension PHAsset {
         options.predicate = Predicate(format: "(mediaSubtype & %d) != 0", PHAssetMediaSubtype.photoScreenshot.rawValue)
         options.sortDescriptors = [SortDescriptor(key: "creationDate", ascending: false)]
         
-        return PHAsset.fetchAssets(with: .image, options: options).firstObject as? PHAsset
+        return PHAsset.fetchAssets(with: .image, options: options).firstObject
     }
 }
 

--- a/PinpointKit/PinpointKit/Sources/ScreenshotDetector.swift
+++ b/PinpointKit/PinpointKit/Sources/ScreenshotDetector.swift
@@ -77,7 +77,7 @@ public class ScreenshotDetector: NSObject {
         
         imageManager.requestImage(for: screenshot,
             targetSize: PHImageManagerMaximumSize,
-            contentMode: PHImageContentMode(),
+            contentMode: .default,
             options: PHImageRequestOptions.highQualitySynchronousLocalOptions()) { [weak self] image, info in
             OperationQueue.main().addOperation {
                 guard let strongSelf = self else { return }

--- a/PinpointKit/PinpointKit/Sources/ScreenshotDetector.swift
+++ b/PinpointKit/PinpointKit/Sources/ScreenshotDetector.swift
@@ -15,22 +15,22 @@ import Photos
 public class ScreenshotDetector: NSObject {
     
     /// An error encountered when detecting and retreiving a screenshot.
-    enum Error: ErrorType {
+    enum Error: ErrorProtocol {
         /// The user did not give authorization to this application to their Photo Library.
-        case Unauthorized(status: PHAuthorizationStatus)
+        case unauthorized(status: PHAuthorizationStatus)
         
         /// The screenshot metadata could not be fetched from the library.
-        case FetchFailure
+        case fetchFailure
         
         /// The screenshot image data could not be loaded from the library.
-        case LoadFailure
+        case loadFailure
     }
     
     /// A boolean value indicating whether the detector is enabled. When set to true, the detector will request photo access whenever a screenshot is taken by the user and deliver screenshots to its delegate.
     public var detectionEnabled: Bool = true
     
     private weak var delegate: ScreenshotDetectorDelegate?
-    private let notificationCenter: NSNotificationCenter
+    private let notificationCenter: NotificationCenter
     private let application: UIApplication
     private let imageManager: PHImageManager
     
@@ -42,7 +42,7 @@ public class ScreenshotDetector: NSObject {
      - parameter application:        An application that will be the `object` of the notification observer.
      - parameter imageManager:       An image manager used to fetch the image data of the screenshot.
      */
-    init(delegate: ScreenshotDetectorDelegate, notificationCenter: NSNotificationCenter = .defaultCenter(), application: UIApplication = .sharedApplication(), imageManager: PHImageManager = .defaultManager()) {
+    init(delegate: ScreenshotDetectorDelegate, notificationCenter: NotificationCenter = .default(), application: UIApplication = .shared(), imageManager: PHImageManager = .default()) {
         self.delegate = delegate
         self.notificationCenter = notificationCenter
         self.application = application
@@ -50,10 +50,10 @@ public class ScreenshotDetector: NSObject {
         
         super.init()
         
-        notificationCenter.addObserver(self, selector: #selector(ScreenshotDetector.userTookScreenshot(_:)), name: UIApplicationUserDidTakeScreenshotNotification, object: application)
+        notificationCenter.addObserver(self, selector: #selector(ScreenshotDetector.userTookScreenshot(_:)), name: NSNotification.Name.UIApplicationUserDidTakeScreenshot, object: application)
     }
     
-    @objc private func userTookScreenshot(notification: NSNotification) {
+    @objc private func userTookScreenshot(_ notification: Notification) {
         guard detectionEnabled else { return }
         
         requestPhotosAuthorization()
@@ -61,38 +61,38 @@ public class ScreenshotDetector: NSObject {
     
     private func requestPhotosAuthorization() {
         PHPhotoLibrary.requestAuthorization { authorizationStatus in
-            NSOperationQueue.mainQueue().addOperationWithBlock {
+            OperationQueue.main().addOperation {
                 switch authorizationStatus {
-                case .Authorized:
+                case .authorized:
                     self.findScreenshot()
-                case .Denied, .NotDetermined, .Restricted:
-                    self.fail(.Unauthorized(status: authorizationStatus))
+                case .denied, .notDetermined, .restricted:
+                    self.fail(.unauthorized(status: authorizationStatus))
                 }
             }
         }
     }
     
     private func findScreenshot() {
-        guard let screenshot = PHAsset.fetchLastScreenshot() else { fail(.FetchFailure); return }
+        guard let screenshot = PHAsset.fetchLastScreenshot() else { fail(.fetchFailure); return }
         
-        imageManager.requestImageForAsset(screenshot,
+        imageManager.requestImage(for: screenshot,
             targetSize: PHImageManagerMaximumSize,
-            contentMode: PHImageContentMode.Default,
+            contentMode: PHImageContentMode(),
             options: PHImageRequestOptions.highQualitySynchronousLocalOptions()) { [weak self] image, info in
-            NSOperationQueue.mainQueue().addOperationWithBlock {
+            OperationQueue.main().addOperation {
                 guard let strongSelf = self else { return }
-                guard let image = image else { strongSelf.fail(.LoadFailure); return }
+                guard let image = image else { strongSelf.fail(.loadFailure); return }
                 
                 strongSelf.succeed(image)
             }
         }
     }
     
-    private func succeed(image: UIImage) {
+    private func succeed(_ image: UIImage) {
         delegate?.screenshotDetector(self, didDetectScreenshot: image)
     }
     
-    private func fail(error: Error) {
+    private func fail(_ error: Error) {
         delegate?.screenshotDetector(self, didFailWithError: error)
     }
 }
@@ -108,7 +108,7 @@ protocol ScreenshotDetectorDelegate: class {
      - parameter screenshotDetector: The detector responsible for the message.
      - parameter screenshot:         The screeenshot that was detected.
      */
-    func screenshotDetector(screenshotDetector: ScreenshotDetector, didDetectScreenshot screenshot: UIImage)
+    func screenshotDetector(_ screenshotDetector: ScreenshotDetector, didDetectScreenshot screenshot: UIImage)
     
     /**
      Notifies the delegate that the detector failed to detect a screenshot.
@@ -116,7 +116,7 @@ protocol ScreenshotDetectorDelegate: class {
      - parameter screenshotDetector: The detector responsible for the message.
      - parameter error:              The error that occurred while attempting to detecting the screenshot.
      */
-    func screenshotDetector(screenshotDetector: ScreenshotDetector, didFailWithError error: ScreenshotDetector.Error)
+    func screenshotDetector(_ screenshotDetector: ScreenshotDetector, didFailWithError error: ScreenshotDetector.Error)
 }
 
 @available(iOS 9.0, *)
@@ -126,12 +126,12 @@ private extension PHAsset {
         let options = PHFetchOptions()
         
         options.fetchLimit = 1
-        options.includeAssetSourceTypes = [.TypeUserLibrary]
+        options.includeAssetSourceTypes = [.typeUserLibrary]
         options.wantsIncrementalChangeDetails = false
-        options.predicate = NSPredicate(format: "(mediaSubtype & %d) != 0", PHAssetMediaSubtype.PhotoScreenshot.rawValue)
-        options.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
+        options.predicate = Predicate(format: "(mediaSubtype & %d) != 0", PHAssetMediaSubtype.photoScreenshot.rawValue)
+        options.sortDescriptors = [SortDescriptor(key: "creationDate", ascending: false)]
         
-        return PHAsset.fetchAssetsWithMediaType(.Image, options: options).firstObject as? PHAsset
+        return PHAsset.fetchAssets(with: .image, options: options).firstObject as? PHAsset
     }
 }
 
@@ -140,9 +140,9 @@ private extension PHImageRequestOptions {
     
     static func highQualitySynchronousLocalOptions() -> PHImageRequestOptions {
         let options = PHImageRequestOptions()
-        options.deliveryMode = .HighQualityFormat
-        options.networkAccessAllowed = false
-        options.synchronous = true
+        options.deliveryMode = .highQualityFormat
+        options.isNetworkAccessAllowed = false
+        options.isSynchronous = true
         
         return options
     }

--- a/PinpointKit/PinpointKit/Sources/ScreenshotHeaderView.swift
+++ b/PinpointKit/PinpointKit/Sources/ScreenshotHeaderView.swift
@@ -24,21 +24,21 @@ class ScreenshotHeaderView: UIView {
     }
     
     private enum DesignConstants: CGFloat {
-        case DefaultMargin = 15
-        case MinimumScreenshotPadding = 50
+        case defaultMargin = 15
+        case minimumScreenshotPadding = 50
     }
     
     /// Set the `viewData` in order to update the receiver’s content.
     var viewModel: ViewModel? {
         didSet {
-            screenshotButton.setImage(viewModel?.screenshot.imageWithRenderingMode(.AlwaysOriginal), forState: .Normal)
+            screenshotButton.setImage(viewModel?.screenshot.withRenderingMode(.alwaysOriginal), for: UIControlState())
             
             if let screenshot = viewModel?.screenshot {
-                screenshotButtonHeightConstraint = screenshotButton.heightAnchor.constraintEqualToAnchor(screenshotButton.widthAnchor, multiplier: 1.0 / screenshot.aspectRatio)
+                screenshotButtonHeightConstraint = screenshotButton.heightAnchor.constraint(equalTo: screenshotButton.widthAnchor, multiplier: 1.0 / screenshot.aspectRatio)
             }
             
             hintLabel.text = viewModel?.hintText
-            hintLabel.hidden = viewModel?.hintText == nil || viewModel?.hintText?.isEmpty == true
+            hintLabel.isHidden = viewModel?.hintText == nil || viewModel?.hintText?.isEmpty == true
             hintLabel.font = viewModel?.hintFont
         }
     }
@@ -49,20 +49,20 @@ class ScreenshotHeaderView: UIView {
     private let stackView: UIStackView = {
         let stackView = UIStackView()
         
-        stackView.axis = .Vertical
-        stackView.alignment = .Center
+        stackView.axis = .vertical
+        stackView.alignment = .center
         stackView.spacing = 10
         stackView.translatesAutoresizingMaskIntoConstraints = false
         
-        stackView.layoutMargins = UIEdgeInsets(top: DesignConstants.DefaultMargin.rawValue, left: DesignConstants.DefaultMargin.rawValue, bottom: DesignConstants.DefaultMargin.rawValue, right: DesignConstants.DefaultMargin.rawValue)
-        stackView.layoutMarginsRelativeArrangement = true
+        stackView.layoutMargins = UIEdgeInsets(top: DesignConstants.defaultMargin.rawValue, left: DesignConstants.defaultMargin.rawValue, bottom: DesignConstants.defaultMargin.rawValue, right: DesignConstants.defaultMargin.rawValue)
+        stackView.isLayoutMarginsRelativeArrangement = true
         
         return stackView
     }()
     
     private lazy var screenshotButton: UIButton = {
-        let button = UIButton(type: .System)
-        button.layer.borderColor = self.tintColor.CGColor
+        let button = UIButton(type: .system)
+        button.layer.borderColor = self.tintColor.cgColor
         button.layer.borderWidth = 1
         
         return button
@@ -70,14 +70,14 @@ class ScreenshotHeaderView: UIView {
     
     private let hintLabel: UILabel = {
         let label = UILabel()
-        label.textColor = UIColor.lightGrayColor()
+        label.textColor = UIColor.lightGray()
         return label
     }()
     
     private var screenshotButtonHeightConstraint: NSLayoutConstraint? {
         didSet {
-            oldValue?.active = false
-            screenshotButtonHeightConstraint?.active = true
+            oldValue?.isActive = false
+            screenshotButtonHeightConstraint?.isActive = true
         }
     }
     
@@ -97,7 +97,7 @@ class ScreenshotHeaderView: UIView {
     override func tintColorDidChange() {
         super.tintColorDidChange()
         
-        screenshotButton.layer.borderColor = tintColor.CGColor
+        screenshotButton.layer.borderColor = tintColor.cgColor
     }
     
     // MARK: - ScreenshotHeaderView
@@ -105,10 +105,10 @@ class ScreenshotHeaderView: UIView {
     private func setUp() {
         addSubview(stackView)
         
-        stackView.topAnchor.constraintEqualToAnchor(topAnchor).active = true
-        stackView.bottomAnchor.constraintEqualToAnchor(bottomAnchor).active = true
-        stackView.leadingAnchor.constraintEqualToAnchor(leadingAnchor).active = true
-        stackView.trailingAnchor.constraintEqualToAnchor(trailingAnchor).active = true
+        stackView.topAnchor.constraint(equalTo: topAnchor).isActive = true
+        stackView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
+        stackView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
+        stackView.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
         
         stackView.addArrangedSubview(screenshotButton)
         stackView.addArrangedSubview(hintLabel)
@@ -117,15 +117,15 @@ class ScreenshotHeaderView: UIView {
     }
     
     private func setUpScreenshotButton() {
-        screenshotButton.leadingAnchor.constraintGreaterThanOrEqualToAnchor(stackView.leadingAnchor, constant: DesignConstants.MinimumScreenshotPadding.rawValue).active = true
-        screenshotButton.trailingAnchor.constraintLessThanOrEqualToAnchor(stackView.trailingAnchor, constant: -DesignConstants.MinimumScreenshotPadding.rawValue).active = true
+        screenshotButton.leadingAnchor.constraint(greaterThanOrEqualTo: stackView.leadingAnchor, constant: DesignConstants.minimumScreenshotPadding.rawValue).isActive = true
+        screenshotButton.trailingAnchor.constraint(lessThanOrEqualTo: stackView.trailingAnchor, constant: -DesignConstants.minimumScreenshotPadding.rawValue).isActive = true
         
-        screenshotButtonHeightConstraint = screenshotButton.heightAnchor.constraintEqualToAnchor(screenshotButton.widthAnchor, multiplier: 1.0)
+        screenshotButtonHeightConstraint = screenshotButton.heightAnchor.constraint(equalTo: screenshotButton.widthAnchor, multiplier: 1.0)
         
-        screenshotButton.addTarget(self, action: #selector(ScreenshotHeaderView.screenshotButtonTapped(_:)), forControlEvents: .TouchUpInside)
+        screenshotButton.addTarget(self, action: #selector(ScreenshotHeaderView.screenshotButtonTapped(_:)), for: .touchUpInside)
     }
     
-    @objc private func screenshotButtonTapped(sender: UIButton) {
+    @objc private func screenshotButtonTapped(_ sender: UIButton) {
         screenshotButtonTapHandler?(button: sender)
     }
 }

--- a/PinpointKit/PinpointKit/Sources/Screenshotter.swift
+++ b/PinpointKit/PinpointKit/Sources/Screenshotter.swift
@@ -19,18 +19,18 @@ public class Screenshotter {
      
      - returns: A screenshot as a `UIImage`.
      */
-    public static func takeScreenshot(screen: UIScreen = UIScreen.mainScreen(), application: UIApplication = UIApplication.sharedApplication()) -> UIImage {
+    public static func takeScreenshot(_ screen: UIScreen = UIScreen.main(), application: UIApplication = UIApplication.shared()) -> UIImage {
         UIGraphicsBeginImageContextWithOptions(screen.bounds.size, true, 0)
         
         application.windows.forEach { window in
             guard window.screen == screen else { return }
             
-            window.drawViewHierarchyInRect(window.bounds, afterScreenUpdates: false)
+            window.drawHierarchy(in: window.bounds, afterScreenUpdates: false)
         }
         
         let image = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
         
-        return image
+        return image!
     }
 }

--- a/PinpointKit/PinpointKit/Sources/Screenshotter.swift
+++ b/PinpointKit/PinpointKit/Sources/Screenshotter.swift
@@ -28,9 +28,12 @@ public class Screenshotter {
             window.drawHierarchy(in: window.bounds, afterScreenUpdates: false)
         }
         
-        let image = UIGraphicsGetImageFromCurrentImageContext()
+        guard let image = UIGraphicsGetImageFromCurrentImageContext() else {
+            preconditionFailure("`UIGraphicsGetImageFromCurrentImageContext()` should never return `nil` as we satisify the requirements of having a bitmap-based current context created with `UIGraphicsBeginImageContextWithOptions(_:_:_:)`")
+        }
+        
         UIGraphicsEndImageContext()
         
-        return image!
+        return image
     }
 }

--- a/PinpointKit/PinpointKit/Sources/Sender.swift
+++ b/PinpointKit/PinpointKit/Sources/Sender.swift
@@ -20,7 +20,7 @@ public protocol Sender: class {
      - parameter feedback:       The feedback to send.
      - parameter viewController: The view controller from which to present any of the sender’s necessary views.
      */
-    func sendFeedback(feedback: Feedback, fromViewController viewController: UIViewController?)
+    func sendFeedback(_ feedback: Feedback, fromViewController viewController: UIViewController?)
 }
 
 /// A delegate protocol describing an object that receives success and failure events from a `Sender`.
@@ -32,7 +32,7 @@ public protocol SenderDelegate: class {
      - parameter feedback: The feedback that was sent.
      - parameter success:  The optional type of success.
      */
-    func sender(sender: Sender, didSendFeedback feedback: Feedback?, success: SuccessType?)
+    func sender(_ sender: Sender, didSendFeedback feedback: Feedback?, success: SuccessType?)
     
     /**
      Notifies the receiver that the sender failed to send the feedback with a given error.
@@ -41,11 +41,11 @@ public protocol SenderDelegate: class {
      - parameter feedback: The feedback that failed to send.
      - parameter error:    The error that caused the failure.
      */
-    func sender(sender: Sender, didFailToSendFeedback feedback: Feedback?, error: ErrorType)
+    func sender(_ sender: Sender, didFailToSendFeedback feedback: Feedback?, error: ErrorProtocol)
 }
 
 /// An extension on PinpointKitDelegate that makes some of the delegate methods optional by giving them empty implementations by default.
 public extension SenderDelegate {
 
-    func sender(sender: Sender, didFailToSendFeedback feedback: Feedback?, error: ErrorType) { }
+    func sender(_ sender: Sender, didFailToSendFeedback feedback: Feedback?, error: ErrorProtocol) { }
 }

--- a/PinpointKit/PinpointKit/Sources/ShakeDetectingWindow.swift
+++ b/PinpointKit/PinpointKit/Sources/ShakeDetectingWindow.swift
@@ -37,8 +37,8 @@ public class ShakeDetectingWindow: UIWindow {
 	
 	// MARK: - UIResponder
     
-    override public func motionEnded(motion: UIEventSubtype, withEvent event: UIEvent?) {
-        if motion == .MotionShake {
+    override public func motionEnded(_ motion: UIEventSubtype, with event: UIEvent?) {
+        if motion == .motionShake {
             guard let delegate = delegate else {
                 NSLog(#file + "- There is no ShakeDetectingWindowDelegate registered to handle this shake.")
                 return

--- a/PinpointKit/PinpointKit/Sources/ShakeDetectingWindowDelegate.swift
+++ b/PinpointKit/PinpointKit/Sources/ShakeDetectingWindowDelegate.swift
@@ -17,5 +17,5 @@ public protocol ShakeDetectingWindowDelegate: class {
 
      - parameter shakeDetectingWindow: The `ShakeDetectingWindow` in which the shake motion event occurred.
      */
-    func shakeDetectingWindowDidDetectShake(shakeDetectingWindow: ShakeDetectingWindow)
+    func shakeDetectingWindowDidDetectShake(_ shakeDetectingWindow: ShakeDetectingWindow)
 }

--- a/PinpointKit/PinpointKit/Sources/StrokeLayoutManager.swift
+++ b/PinpointKit/PinpointKit/Sources/StrokeLayoutManager.swift
@@ -17,52 +17,52 @@ final class StrokeLayoutManager: NSLayoutManager {
     /// The width of the stroke to display around the text.
     var strokeWidth: CGFloat?
     
-    override func drawGlyphsForGlyphRange(glyphsToShow: NSRange, atPoint origin: CGPoint) {
+    override func drawGlyphs(forGlyphRange glyphsToShow: NSRange, at origin: CGPoint) {
         let context = UIGraphicsGetCurrentContext()
         
-        let firstIndex = characterIndexForGlyphAtIndex(glyphsToShow.location)
-        let attributes = textStorage?.attributesAtIndex(firstIndex, effectiveRange: nil)
+        let firstIndex = characterIndexForGlyph(at: glyphsToShow.location)
+        let attributes = textStorage?.attributes(at: firstIndex, effectiveRange: nil)
         let shadow = attributes?[NSShadowAttributeName] as? NSShadow
         let shouldRenderTransparencyLayer = strokeColor != nil && strokeWidth != nil && shadow != nil
         
         if let shadow = shadow where shouldRenderTransparencyLayer {
             // Applies the shadow to the entire stroke as one layer, insead of overlapping per-character.
-            CGContextSetShadowWithColor(context, shadow.shadowOffset, shadow.shadowBlurRadius, shadow.shadowColor?.CGColor)
-            CGContextBeginTransparencyLayer(context, nil)
+            context?.setShadow(offset: shadow.shadowOffset, blur: shadow.shadowBlurRadius, color: shadow.shadowColor?.cgColor)
+            context?.beginTransparencyLayer(auxiliaryInfo: nil)
         }
         
-        super.drawGlyphsForGlyphRange(glyphsToShow, atPoint: origin)
+        super.drawGlyphs(forGlyphRange: glyphsToShow, at: origin)
         
         if shouldRenderTransparencyLayer {
-            CGContextEndTransparencyLayer(context)
+            context?.endTransparencyLayer()
         }
     }
     
-    override func showCGGlyphs(glyphs: UnsafePointer<CGGlyph>, positions: UnsafePointer<CGPoint>, count glyphCount: Int, font: UIFont, matrix textMatrix: CGAffineTransform, attributes: [String : AnyObject], inContext graphicsContext: CGContext) {
+    override func showCGGlyphs(_ glyphs: UnsafePointer<CGGlyph>, positions: UnsafePointer<CGPoint>, count glyphCount: Int, font: UIFont, matrix textMatrix: CGAffineTransform, attributes: [String : AnyObject], in graphicsContext: CGContext) {
         var textAttributes = attributes
         
         if let strokeColor = strokeColor, strokeWidth = strokeWidth {
             // Remove the shadow. It'll all be drawn at once afterwards.
             textAttributes[NSShadowAttributeName] = nil
-            CGContextSetShadowWithColor(graphicsContext, CGSize.zero, 0, nil)
+            graphicsContext.setShadow(offset: CGSize.zero, blur: 0, color: nil)
             
-            CGContextSaveGState(graphicsContext)
+            graphicsContext.saveGState()
             
             strokeColor.setStroke()
             
-            CGContextSetLineWidth(graphicsContext, strokeWidth)
-            CGContextSetLineJoin(graphicsContext, .Miter)
+            graphicsContext.setLineWidth(strokeWidth)
+            graphicsContext.setLineJoin(.miter)
             
-            CGContextSetTextDrawingMode(graphicsContext, .FillStroke)
+            graphicsContext.setTextDrawingMode(.fillStroke)
             
-            super.showCGGlyphs(glyphs, positions: positions, count: glyphCount, font: font, matrix: textMatrix, attributes: textAttributes, inContext: graphicsContext)
+            super.showCGGlyphs(glyphs, positions: positions, count: glyphCount, font: font, matrix: textMatrix, attributes: textAttributes, in: graphicsContext)
             
             // Due to a bug in iOS 7, kCGTextFillStroke will never have the correct fill color, so we must draw the string twice: once for stroke and once for fill. http://stackoverflow.com/questions/18894907/why-cgcontextsetrgbstrokecolor-isnt-working-on-ios7
             
-            CGContextRestoreGState(graphicsContext)
-            CGContextSetTextDrawingMode(graphicsContext, .Fill)
+            graphicsContext.restoreGState()
+            graphicsContext.setTextDrawingMode(.fill)
         }
         
-        super.showCGGlyphs(glyphs, positions: positions, count: glyphCount, font: font, matrix: textMatrix, attributes: textAttributes, inContext: graphicsContext)
+        super.showCGGlyphs(glyphs, positions: positions, count: glyphCount, font: font, matrix: textMatrix, attributes: textAttributes, in: graphicsContext)
     }
 }

--- a/PinpointKit/PinpointKit/Sources/TextAnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/TextAnnotationView.swift
@@ -19,7 +19,7 @@ public class TextAnnotationView: AnnotationView, UITextViewDelegate {
         let manager = StrokeLayoutManager()
         manager.strokeWidth = 4.5
         
-        let container = NSTextContainer(size: CGSize(width: 0, height: CGFloat.max))
+        let container = NSTextContainer(size: CGSize(width: 0, height: CGFloat.greatestFiniteMagnitude))
         container.widthTracksTextView = true
         
         manager.addTextContainer(container)
@@ -27,8 +27,8 @@ public class TextAnnotationView: AnnotationView, UITextViewDelegate {
         
         let textView = UITextView(frame: CGRect.zero, textContainer: container)
         
-        textView.spellCheckingType = .No
-        textView.scrollEnabled = false
+        textView.spellCheckingType = .no
+        textView.isScrollEnabled = false
         textView.backgroundColor = UIColor(white: 1.0, alpha: 0.3)
         textView.textContainerInset = TextViewInset
         textView.textContainer.lineFragmentPadding = TextViewLineFragmentPadding
@@ -74,13 +74,13 @@ public class TextAnnotationView: AnnotationView, UITextViewDelegate {
         }()
     }
     
-    override public func pointInside(point: CGPoint, withEvent event: UIEvent?) -> Bool {
+    override public func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
         return annotationFrame?.contains(point) ?? false
     }
         
     // MARK: - AnnotationView
     
-    override func moveControlPoints(translation: CGPoint) {
+    override func moveControlPoints(_ translation: CGPoint) {
         textView.frame = {
             var textViewFrame = self.textView.frame
             textViewFrame.origin = CGPoint(x: textViewFrame.minX + translation.x, y: textViewFrame.minY + translation.y)
@@ -106,7 +106,7 @@ public class TextAnnotationView: AnnotationView, UITextViewDelegate {
     }
     
     private var font: UIFont {
-        return UITextView.appearanceWhenContainedInInstancesOfClasses([TextAnnotationView.self]).font ?? UIFont.systemFontOfSize(32)
+        return UITextView.whenContained(inInstancesOfClasses: [TextAnnotationView.self]).font ?? UIFont.systemFont(ofSize: 32)
     }
     
     /// The minimum text size for the annotation view.
@@ -115,7 +115,7 @@ public class TextAnnotationView: AnnotationView, UITextViewDelegate {
         let character = "." as NSString
         let textFont = textAttributes[NSFontAttributeName] ?? font
         
-        let size = character.boundingRectWithSize(CGSize(width: width, height: CGFloat.max), options: .UsesLineFragmentOrigin, attributes: [NSFontAttributeName: textFont], context: nil)
+        let size = character.boundingRect(with: CGSize(width: width, height: CGFloat.greatestFiniteMagnitude), options: .usesLineFragmentOrigin, attributes: [NSFontAttributeName: textFont], context: nil)
         return CGSize(width: width, height: size.height + TextAnnotationView.TextViewInset.top + TextAnnotationView.TextViewInset.bottom + TextAnnotationView.TextViewLineFragmentPadding)
     }
     
@@ -136,7 +136,7 @@ public class TextAnnotationView: AnnotationView, UITextViewDelegate {
                 minHeight = minimumTextSize.height
             }
             
-            let size = CGSize(width: textViewFrame.width, height: CGFloat.max)
+            let size = CGSize(width: textViewFrame.width, height: CGFloat.greatestFiniteMagnitude)
             
             textViewFrame.size.height = max(textView.sizeThatFits(size).height, minHeight)
             
@@ -148,28 +148,28 @@ public class TextAnnotationView: AnnotationView, UITextViewDelegate {
      Tells the internal text view to begin editing.
      */
     func beginEditing() {
-        textView.selectable = true
-        textView.editable = true
+        textView.isSelectable = true
+        textView.isEditable = true
         textView.becomeFirstResponder()
     }
     
     // MARK: - UITextViewDelegate
     
-    public func textViewDidChange(textView: UITextView) {
+    public func textViewDidChange(_ textView: UITextView) {
         updateTextViewFrame()
     }
     
-    public func textViewDidBeginEditing(textView: UITextView) {
+    public func textViewDidBeginEditing(_ textView: UITextView) {
         textView.backgroundColor = UIColor(white: 1.0, alpha: 0.3)
         textView.layer.borderWidth = 1
-        textView.layer.borderColor = tintColor.colorWithAlphaComponent(self.dynamicType.BorderAlpha).CGColor
+        textView.layer.borderColor = tintColor.withAlphaComponent(self.dynamicType.BorderAlpha).cgColor
     }
     
-    public func textViewDidEndEditing(textView: UITextView) {
-        textView.selectable = false
-        textView.editable = false
+    public func textViewDidEndEditing(_ textView: UITextView) {
+        textView.isSelectable = false
+        textView.isEditable = false
         
-        textView.backgroundColor = UIColor.clearColor()
+        textView.backgroundColor = UIColor.clear()
         textView.layer.borderWidth = 0
         textView.layer.borderColor = nil
     }

--- a/PinpointKit/PinpointKit/Sources/UIGestureRecognizer+FailRecognizing.swift
+++ b/PinpointKit/PinpointKit/Sources/UIGestureRecognizer+FailRecognizing.swift
@@ -15,12 +15,12 @@ extension UIGestureRecognizer {
      Function that forces a gesture recognizer to fail
      */
     func failRecognizing() {
-        if !enabled {
+        if !isEnabled {
             return
         }
         
         // Disabling and enabling causes recognizing to fail.
-        enabled = false
-        enabled = true
+        isEnabled = false
+        isEnabled = true
     }
 }

--- a/PinpointKit/PinpointKit/Sources/UIView+PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/UIView+PinpointKit.swift
@@ -12,9 +12,9 @@ extension UIView {
     /// The UIImage representation of this view at the time of access.
     var pinpoint_screenshot: UIImage {
         UIGraphicsBeginImageContextWithOptions(bounds.size, true, 0)
-        drawViewHierarchyInRect(bounds, afterScreenUpdates: true)
+        drawHierarchy(in: bounds, afterScreenUpdates: true)
         let image = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
-        return image
+        return image!
     }
 }

--- a/PinpointKit/PinpointKit/Sources/UIView+PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/UIView+PinpointKit.swift
@@ -13,8 +13,13 @@ extension UIView {
     var pinpoint_screenshot: UIImage {
         UIGraphicsBeginImageContextWithOptions(bounds.size, true, 0)
         drawHierarchy(in: bounds, afterScreenUpdates: true)
-        let image = UIGraphicsGetImageFromCurrentImageContext()
+        
+        guard let image = UIGraphicsGetImageFromCurrentImageContext() else {
+            preconditionFailure("`UIGraphicsGetImageFromCurrentImageContext()` should never return `nil` as we satisify the requirements of having a bitmap-based current context created with `UIGraphicsBeginImageContextWithOptions(_:_:_:)`")
+        }
+        
         UIGraphicsEndImageContext()
-        return image!
+        
+        return image
     }
 }

--- a/PinpointKit/PinpointKitTests/PinpointKitTests.swift
+++ b/PinpointKit/PinpointKitTests/PinpointKitTests.swift
@@ -28,7 +28,7 @@ class PinpointKitTests: XCTestCase {
     
     func testPerformanceExample() {
         // This is an example of a performance test case.
-        self.measureBlock {
+        self.measure {
             // Put the code you want to measure the time of here.
         }
     }


### PR DESCRIPTION
Progress on #123

📝 This is pointing at the new `swift-3.0` branch, not `develop`.

- Runs the migrator in Xcode 8 to update to Swift 3.0 syntax. This was all performed in c880af1.
- All other commits can / should be reviewed independently to fully understand the need for the changes. They fix leftover compiler errors, migrator-introduced force unwrapping that wasn't necessary, or sub-optimal optional chaining.

To keep this from being difficult to review, I’m deferring following of the [API Design Guidelines](https://swift.org/documentation/api-design-guidelines/) for introduced APIs to a separate branch and pull request.