### PR TITLE
Easier Specification Of Email Recipients

### DIFF
--- a/Example/PinpointKitExample/AppDelegate.swift
+++ b/Example/PinpointKitExample/AppDelegate.swift
@@ -11,9 +11,8 @@ import PinpointKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-    private let pinpointKit = PinpointKit(feedbackRecipients: ["feedback@example.com"])
-    lazy var window: UIWindow? = ShakeDetectingWindow(frame: UIScreen.mainScreen().bounds, delegate: self.pinpointKit)
+    
+    var window: UIWindow?
     
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         NSLog("Initial test log for the system logger.")

--- a/Example/PinpointKitExample/AppDelegate.swift
+++ b/Example/PinpointKitExample/AppDelegate.swift
@@ -12,7 +12,8 @@ import PinpointKit
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    lazy var window: UIWindow? = ShakeDetectingWindow(frame: UIScreen.mainScreen().bounds)
+    let pinpointKit = PinpointKit(feedbackRecipients: ["feedback@example.com"])
+    lazy var window: UIWindow? = ShakeDetectingWindow(frame: UIScreen.mainScreen().bounds, delegate: self.pinpointKit)
     
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         NSLog("Initial test log for the system logger.")

--- a/Example/PinpointKitExample/AppDelegate.swift
+++ b/Example/PinpointKitExample/AppDelegate.swift
@@ -12,7 +12,7 @@ import PinpointKit
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    let pinpointKit = PinpointKit(feedbackRecipients: ["feedback@example.com"])
+    private let pinpointKit = PinpointKit(feedbackRecipients: ["feedback@example.com"])
     lazy var window: UIWindow? = ShakeDetectingWindow(frame: UIScreen.mainScreen().bounds, delegate: self.pinpointKit)
     
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {

--- a/Example/PinpointKitExample/ViewController.swift
+++ b/Example/PinpointKitExample/ViewController.swift
@@ -11,6 +11,8 @@ import PinpointKit
 
 final class ViewController: UITableViewController {
     
+    let pinpointKit = PinpointKit(feedbackRecipients: ["feedback@example.com"])
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -21,6 +23,6 @@ final class ViewController: UITableViewController {
     override func viewDidAppear(animated: Bool) {
         super.viewDidAppear(animated)
         
-        PinpointKit.defaultPinpointKit.show(fromViewController: self)
+        pinpointKit.show(fromViewController: self)
     }
 }

--- a/Example/PinpointKitExample/ViewController.swift
+++ b/Example/PinpointKitExample/ViewController.swift
@@ -11,7 +11,7 @@ import PinpointKit
 
 final class ViewController: UITableViewController {
     
-    let pinpointKit = PinpointKit(feedbackRecipients: ["feedback@example.com"])
+    private let pinpointKit = PinpointKit(feedbackRecipients: ["feedback@example.com"])
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/PinpointKit/PinpointKit/Sources/Configuration.swift
+++ b/PinpointKit/PinpointKit/Sources/Configuration.swift
@@ -60,7 +60,7 @@ public struct Configuration {
                 feedbackCollector: FeedbackCollector = FeedbackNavigationController(),
                 editor: Editor = EditImageViewController(),
                 sender: Sender = MailSender(),
-                feedbackRecipients: [String]? = nil) {
+                feedbackRecipients: [String]) {
         self.feedbackCollector = feedbackCollector
         self.editor = editor
         

--- a/PinpointKit/PinpointKit/Sources/PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/PinpointKit.swift
@@ -11,10 +11,7 @@ import Foundation
 
 /// `PinpointKit` is an object that can be used to collect feedback from application users.
 public class PinpointKit {
-
-    /// Returns a `PinpointKit` instance with a default configuration.
-    public static let defaultPinpointKit = PinpointKit()
-
+    
     /// The configuration struct that specifies how PinpointKit should be configured.
     private let configuration: Configuration
     
@@ -29,12 +26,24 @@ public class PinpointKit {
      - parameter configuration: The configuration struct that specifies how PinpointKit should be configured.
      - parameter delegate:      A delegate that is notified of significant events.
      */
-    public init(configuration: Configuration = Configuration(), delegate: PinpointKitDelegate? = nil) {
+    public init(configuration: Configuration, delegate: PinpointKitDelegate? = nil) {
         self.configuration = configuration
         self.delegate = delegate
         
         self.configuration.feedbackCollector.feedbackDelegate = self
         self.configuration.sender.delegate = self
+    }
+    
+    /**
+     Initializes a `PinpointKit` with a default configuration supplied with feedback recipients and an optional delegate.
+     
+     - parameter feedbackRecipients: The recipients of the feedback submission. Suitable for email recipients in the "To:" field.
+     - parameter delegate:           A delegate that is notified of significant events.
+     */
+    public convenience init(feedbackRecipients: [String], delegate: PinpointKitDelegate? = nil) {
+        let configuration = Configuration(feedbackRecipients: feedbackRecipients)
+        
+        self.init(configuration: configuration, delegate: delegate)
     }
     
     /**

--- a/PinpointKit/PinpointKit/Sources/ShakeDetectingWindow.swift
+++ b/PinpointKit/PinpointKit/Sources/ShakeDetectingWindow.swift
@@ -13,17 +13,15 @@ import UIKit
 public class ShakeDetectingWindow: UIWindow {
 
     /// A `ShakeDetectingWindowDelegate` to notify when a shake motion event occurs.
-	public weak var delegate: ShakeDetectingWindowDelegate?
+	public weak var delegate: ShakeDetectingWindowDelegate? = nil
 
     /**
      Initializes a `ShakeDetectingWindow`.
 
      - parameter frame:    The frame rectangle for the view.
-     - parameter delegate: An object to notify when a shake motion event occurs. Defaults to `PinpointKit.defaultPinpointKit`.
+     - parameter delegate: An object to notify when a shake motion event occurs.
      */
-	required public init(
-        frame: CGRect,
-        delegate: ShakeDetectingWindowDelegate = PinpointKit.defaultPinpointKit) {
+	required public init(frame: CGRect, delegate: ShakeDetectingWindowDelegate) {
         self.delegate = delegate
         super.init(frame: frame)
 	}
@@ -32,7 +30,6 @@ public class ShakeDetectingWindow: UIWindow {
     
 	required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-	    delegate = PinpointKit.defaultPinpointKit
 	}
 	
 	// MARK: - UIResponder

--- a/PinpointKit/PinpointKit/Sources/ShakeDetectingWindow.swift
+++ b/PinpointKit/PinpointKit/Sources/ShakeDetectingWindow.swift
@@ -13,7 +13,7 @@ import UIKit
 public class ShakeDetectingWindow: UIWindow {
 
     /// A `ShakeDetectingWindowDelegate` to notify when a shake motion event occurs.
-	public weak var delegate: ShakeDetectingWindowDelegate? = nil
+	public weak var delegate: ShakeDetectingWindowDelegate?
 
     /**
      Initializes a `ShakeDetectingWindow`.


### PR DESCRIPTION
Closes #124

The example given in #124 would be nice, but would require exposing `PinpointKit`’s configuration as a `var` would introduce shared mutable state on `PinpointKit`, which is avoided in much of the framework. Instead, I dropped `defaultPinpointKit` and added a convenience initializer to `PinpointKit` to keep things immutable:

```swift
public convenience init(feedbackRecipients: [String], delegate: PinpointKitDelegate? = nil) {
    let configuration = Configuration(feedbackRecipients: feedbackRecipients)
      
    self.init(configuration: configuration, delegate: delegate)
}
```

I’m open to discussion on the pros and cons of both approaches. Now, instead of using `PinpointKit.defaultPinpointKit`, for use with `ShakeDetectingWindow`:

```swift
class AppDelegate: UIResponder, UIApplicationDelegate {
    let pinpointKit = PinpointKit(feedbackRecipients: ["feedback@example.com"])
    lazy var window: UIWindow? = ShakeDetectingWindow(frame: UIScreen.mainScreen().bounds, delegate: self.pinpointKit)
}
```

Note since we no longer have `defaultPinpointKit` which lives forever, the caller must keep a reference to their configured `PinpointKit`. This is because the `ShakeDetectingWindow`’s `delegate` is `weak` (as it should be), and we’re using an instance of `PinpointKit` as the `delegate`.

Similarly, without `ShakeDetectingWindow`, in our example project, we must keep a separate reference to our `PinpointKit`:


```diff
final class ViewController: UITableViewController {
    
+   let pinpointKit = PinpointKit(feedbackRecipients: ["feedback@example.com"])
    
    override func viewDidLoad() {
        super.viewDidLoad()
        
        // Hides the infinite cells footer.
        tableView.tableFooterView = UIView()
    }
    
    override func viewDidAppear(animated: Bool) {
        super.viewDidAppear(animated)

-       PinpointKit.defaultPinpointKit.show(fromViewController: self)        
+       pinpointKit.show(fromViewController: self)
    }
}
```