### PR TITLE
Swift 3.0 API Guidelines Pass 2

### DIFF
--- a/Example/PinpointKitExample/ViewController.swift
+++ b/Example/PinpointKitExample/ViewController.swift
@@ -21,6 +21,6 @@ final class ViewController: UITableViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        PinpointKit.defaultPinpointKit.show(fromViewController: self)
+        PinpointKit.defaultPinpointKit.show(from: self)
     }
 }

--- a/PinpointKit/PinpointKit/Sources/AnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/AnnotationView.swift
@@ -24,11 +24,11 @@ public class AnnotationView: UIView {
     // MARK: - Helpers
     
     /**
-     Moves the control points of the annotation by the amount specified in `translation`.
+     Moves the control points of the annotation by the amount specified in `translationAmount`.
      
-     - parameter translation: The amount to translate the control points.
+     - parameter translationAmount: The amount to translate the control points.
      */
-    func moveControlPoints(_ translation: CGPoint) {
+    func move(controlPointsBy translationAmount: CGPoint) {
         
     }
     

--- a/PinpointKit/PinpointKit/Sources/AnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/AnnotationView.swift
@@ -33,11 +33,11 @@ public class AnnotationView: UIView {
     }
     
     /**
-     Scales the control points of the annotation by the amount specified in `scale`.
+     Scales the control points of the annotation by the amount specified in `scaleFactor`.
      
-     - parameter scale: The factor by which to scale the annotation.
+     - parameter scaleFactor: The factor by which to scale the annotation.
      */
-    func scaleControlPoints(_ scale: CGFloat) {
+    func scale(controlPointsBy scaleFactor: CGFloat) {
         
     }
     

--- a/PinpointKit/PinpointKit/Sources/ArrowAnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/ArrowAnnotationView.swift
@@ -85,10 +85,10 @@ public class ArrowAnnotationView: AnnotationView {
         annotation = ArrowAnnotation(startLocation: startLocation, endLocation: endLocation, strokeColor: previousAnnotation.strokeColor)
     }
     
-    override func scaleControlPoints(_ scale: CGFloat) {
+    override func scale(controlPointsBy scaleFactor: CGFloat) {
         guard let previousAnnotation = annotation else { return }
-        let startLocation = previousAnnotation.scaledPoint(previousAnnotation.startLocation, scale: scale)
-        let endLocation = previousAnnotation.scaledPoint(previousAnnotation.endLocation, scale: scale)
+        let startLocation = previousAnnotation.scaledPoint(previousAnnotation.startLocation, scale: scaleFactor)
+        let endLocation = previousAnnotation.scaledPoint(previousAnnotation.endLocation, scale: scaleFactor)
         
         annotation = ArrowAnnotation(startLocation: startLocation, endLocation: endLocation, strokeColor: previousAnnotation.strokeColor)
     }

--- a/PinpointKit/PinpointKit/Sources/ArrowAnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/ArrowAnnotationView.swift
@@ -77,10 +77,10 @@ public class ArrowAnnotationView: AnnotationView {
         annotation = ArrowAnnotation(startLocation: previousAnnotation.startLocation, endLocation: point, strokeColor: previousAnnotation.strokeColor)
     }
 
-    override func moveControlPoints(_ translation: CGPoint) {
+    override func move(controlPointsBy translationAmount: CGPoint) {
         guard let previousAnnotation = annotation else { return }
-        let startLocation = CGPoint(x: previousAnnotation.startLocation.x + translation.x, y: previousAnnotation.startLocation.y + translation.y)
-        let endLocation = CGPoint(x: previousAnnotation.endLocation.x + translation.x, y: previousAnnotation.endLocation.y + translation.y)
+        let startLocation = CGPoint(x: previousAnnotation.startLocation.x + translationAmount.x, y: previousAnnotation.startLocation.y + translationAmount.y)
+        let endLocation = CGPoint(x: previousAnnotation.endLocation.x + translationAmount.x, y: previousAnnotation.endLocation.y + translationAmount.y)
         
         annotation = ArrowAnnotation(startLocation: startLocation, endLocation: endLocation, strokeColor: previousAnnotation.strokeColor)
     }

--- a/PinpointKit/PinpointKit/Sources/BlurAnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/BlurAnnotationView.swift
@@ -129,10 +129,10 @@ public class BlurAnnotationView: AnnotationView, GLKViewDelegate {
         annotation = BlurAnnotation(startLocation: startLocation, endLocation: endLocation, image: previousAnnotation.image)
     }
 
-    override func scaleControlPoints(_ scale: CGFloat) {
+    override func scale(controlPointsBy scaleFactor: CGFloat) {
         guard let previousAnnotation = annotation else { return }
-        let startLocation = previousAnnotation.scaledPoint(previousAnnotation.startLocation, scale: scale)
-        let endLocation = previousAnnotation.scaledPoint(previousAnnotation.endLocation, scale: scale)
+        let startLocation = previousAnnotation.scaledPoint(previousAnnotation.startLocation, scale: scaleFactor)
+        let endLocation = previousAnnotation.scaledPoint(previousAnnotation.endLocation, scale: scaleFactor)
         
         annotation = BlurAnnotation(startLocation: startLocation, endLocation: endLocation, image: previousAnnotation.image)
     }

--- a/PinpointKit/PinpointKit/Sources/BlurAnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/BlurAnnotationView.swift
@@ -84,8 +84,7 @@ public class BlurAnnotationView: AnnotationView, GLKViewDelegate {
     public required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
-
+    
     // MARK: - UIView
 
     override public func layoutSubviews() {

--- a/PinpointKit/PinpointKit/Sources/BlurAnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/BlurAnnotationView.swift
@@ -121,10 +121,10 @@ public class BlurAnnotationView: AnnotationView, GLKViewDelegate {
         annotation = BlurAnnotation(startLocation: previousAnnotation.startLocation, endLocation: point, image: previousAnnotation.image)
     }
 
-    override func moveControlPoints(_ translation: CGPoint) {
+    override func move(controlPointsBy translationAmount: CGPoint) {
         guard let previousAnnotation = annotation else { return }
-        let startLocation = CGPoint(x: previousAnnotation.startLocation.x + translation.x, y: previousAnnotation.startLocation.y + translation.y)
-        let endLocation = CGPoint(x: previousAnnotation.endLocation.x + translation.x, y: previousAnnotation.endLocation.y + translation.y)
+        let startLocation = CGPoint(x: previousAnnotation.startLocation.x + translationAmount.x, y: previousAnnotation.startLocation.y + translationAmount.y)
+        let endLocation = CGPoint(x: previousAnnotation.endLocation.x + translationAmount.x, y: previousAnnotation.endLocation.y + translationAmount.y)
         
         annotation = BlurAnnotation(startLocation: startLocation, endLocation: endLocation, image: previousAnnotation.image)
     }

--- a/PinpointKit/PinpointKit/Sources/BoxAnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/BoxAnnotationView.swift
@@ -84,10 +84,10 @@ public class BoxAnnotationView: AnnotationView {
         annotation = BoxAnnotation(startLocation: previousAnnotation.startLocation, endLocation: point, strokeColor: previousAnnotation.strokeColor)
     }
 
-    override func moveControlPoints(_ translation: CGPoint) {
+    override func move(controlPointsBy translationAmount: CGPoint) {
         guard let previousAnnotation = annotation else { return }
-        let startLocation = CGPoint(x: previousAnnotation.startLocation.x + translation.x, y: previousAnnotation.startLocation.y + translation.y)
-        let endLocation = CGPoint(x: previousAnnotation.endLocation.x + translation.x, y: previousAnnotation.endLocation.y + translation.y)
+        let startLocation = CGPoint(x: previousAnnotation.startLocation.x + translationAmount.x, y: previousAnnotation.startLocation.y + translationAmount.y)
+        let endLocation = CGPoint(x: previousAnnotation.endLocation.x + translationAmount.x, y: previousAnnotation.endLocation.y + translationAmount.y)
         
         annotation = BoxAnnotation(startLocation: startLocation, endLocation: endLocation, strokeColor: previousAnnotation.strokeColor)
     }

--- a/PinpointKit/PinpointKit/Sources/BoxAnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/BoxAnnotationView.swift
@@ -92,10 +92,10 @@ public class BoxAnnotationView: AnnotationView {
         annotation = BoxAnnotation(startLocation: startLocation, endLocation: endLocation, strokeColor: previousAnnotation.strokeColor)
     }
     
-    override func scaleControlPoints(_ scale: CGFloat) {
+    override func scale(controlPointsBy scaleFactor: CGFloat) {
         guard let previousAnnotation = annotation else { return }
-        let startLocation = previousAnnotation.scaledPoint(previousAnnotation.startLocation, scale: scale)
-        let endLocation = previousAnnotation.scaledPoint(previousAnnotation.endLocation, scale: scale)
+        let startLocation = previousAnnotation.scaledPoint(previousAnnotation.startLocation, scale: scaleFactor)
+        let endLocation = previousAnnotation.scaledPoint(previousAnnotation.endLocation, scale: scaleFactor)
         
         annotation = BoxAnnotation(startLocation: startLocation, endLocation: endLocation, strokeColor: previousAnnotation.strokeColor)
     }

--- a/PinpointKit/PinpointKit/Sources/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Editing/EditImageViewController.swift
@@ -522,7 +522,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         let currentLocation = gestureRecognizer.location(in: gestureRecognizer.view)
         let previousLocation: CGPoint = previousUpdateAnnotationPanGestureRecognizerLocation
         let offset = CGPoint(x: currentLocation.x - previousLocation.x, y: currentLocation.y - previousLocation.y)
-        currentAnnotationView?.moveControlPoints(offset)
+        currentAnnotationView?.move(controlPointsBy: offset)
         previousUpdateAnnotationPanGestureRecognizerLocation = gestureRecognizer.location(in: gestureRecognizer.view)
     }
     

--- a/PinpointKit/PinpointKit/Sources/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Editing/EditImageViewController.swift
@@ -561,7 +561,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
     
     private func handleUpdateAnnotationPinchGestureRecognizerChanged(_ gestureRecognizer: UIPinchGestureRecognizer) {
         if previousUpdateAnnotationPinchScale != 0 {
-            currentAnnotationView?.scaleControlPoints(gestureRecognizer.scale / previousUpdateAnnotationPinchScale)
+            currentAnnotationView?.scale(controlPointsBy: (gestureRecognizer.scale / previousUpdateAnnotationPinchScale))
         }
         
         previousUpdateAnnotationPinchScale = gestureRecognizer.scale

--- a/PinpointKit/PinpointKit/Sources/Fonts.swift
+++ b/PinpointKit/PinpointKit/Sources/Fonts.swift
@@ -48,7 +48,7 @@ public extension UIFont {
             CTFontManagerRegisterFontsForURL(fontURL, .process, nil)
         }
         
-        return UIFont(name: fontName, size: fontSize) ?? UIFont.systemFont(ofSize: fontSize)
+        return UIFont(name: fontName, size: fontSize) ?? .systemFont(ofSize: fontSize)
     }
     
     /**
@@ -59,6 +59,6 @@ public extension UIFont {
      - returns: A `UIFont` representing Menlo Regular at the specified size.
      */
     public static func menloRegularFont(ofSize fontSize: CGFloat) -> UIFont {
-        return UIFont(name: "Menlo-Regular", size: fontSize) ?? UIFont.systemFont(ofSize: fontSize)
+        return UIFont(name: "Menlo-Regular", size: fontSize) ?? .systemFont(ofSize: fontSize)
     }
 }

--- a/PinpointKit/PinpointKit/Sources/InterfaceCustomization.swift
+++ b/PinpointKit/PinpointKit/Sources/InterfaceCustomization.swift
@@ -83,7 +83,7 @@ public struct InterfaceCustomization {
          - parameter editorTextAnnotationFont:           The font used for text annotations in the editor.
          - parameter editorTextAnnotationDoneButtonFont: The font used for the done button in the editor displayed while editing a text annotation.
          */
-        public init(tintColor: UIColor? = .pinpointOrangeColor(),
+        public init(tintColor: UIColor? = .pinpointOrange(),
                     annotationFillColor: UIColor? = nil,
                     annotationStrokeColor: UIColor = .white(),
                     navigationTitleFont: UIFont = .sourceSansProFont(ofSize: 19, weight: .semibold),

--- a/PinpointKit/PinpointKit/Sources/MailSender.swift
+++ b/PinpointKit/PinpointKit/Sources/MailSender.swift
@@ -59,7 +59,7 @@ public class MailSender: NSObject, Sender {
      - parameter feedback:       The feedback to send.
      - parameter viewController: The view controller from which to present any of the sender’s necessary views.
      */
-    public func sendFeedback(_ feedback: Feedback, fromViewController viewController: UIViewController?) {
+    public func send(_ feedback: Feedback, from viewController: UIViewController?) {
         guard let viewController = viewController else { fail(.noViewControllerProvided); return }
         
         guard MFMailComposeViewController.canSendMail() else { fail(.mailCannotSend); return }

--- a/PinpointKit/PinpointKit/Sources/MailSender.swift
+++ b/PinpointKit/PinpointKit/Sources/MailSender.swift
@@ -60,9 +60,9 @@ public class MailSender: NSObject, Sender {
      - parameter viewController: The view controller from which to present any of the sender’s necessary views.
      */
     public func send(_ feedback: Feedback, from viewController: UIViewController?) {
-        guard let viewController = viewController else { fail(.noViewControllerProvided); return }
+        guard let viewController = viewController else { fail(with: .noViewControllerProvided); return }
         
-        guard MFMailComposeViewController.canSendMail() else { fail(.mailCannotSend); return }
+        guard MFMailComposeViewController.canSendMail() else { fail(with: .mailCannotSend); return }
         
         let mailComposer = MFMailComposeViewController()
         mailComposer.mailComposeDelegate = self
@@ -72,9 +72,9 @@ public class MailSender: NSObject, Sender {
         do {
             try mailComposer.attach(feedback)
         } catch let error as Error {
-            fail(error)
+            fail(with: error)
         } catch {
-            fail(.unknown)
+            fail(with: .unknown)
         }
         
         viewController.present(mailComposer, animated: true, completion: nil)
@@ -82,12 +82,12 @@ public class MailSender: NSObject, Sender {
     
     // MARK: - MailSender
     
-    private func fail(_ error: Error) {
+    private func fail(with error: Error) {
         delegate?.sender(self, didFailToSend: feedback, error: error)
         feedback = nil
     }
     
-    private func succeed(_ success: Success) {
+    private func succeed(with success: Success) {
         delegate?.sender(self, didSend: feedback, success: success)
         feedback = nil
     }
@@ -159,13 +159,13 @@ extension MailSender: MFMailComposeViewControllerDelegate {
     private func completeWithResult(_ result: MFMailComposeResult, error: NSError?) {
         switch result {
         case .cancelled:
-            fail(.mailCanceled(underlyingError: error))
+            fail(with: .mailCanceled(underlyingError: error))
         case .failed:
-            fail(.mailFailed(underlyingError: error))
+            fail(with: .mailFailed(underlyingError: error))
         case .saved:
-            succeed(.saved)
+            succeed(with: .saved)
         case .sent:
-            succeed(.sent)
+            succeed(with: .sent)
         }
     }
 }

--- a/PinpointKit/PinpointKit/Sources/PinpointKit+ShakePresentation.swift
+++ b/PinpointKit/PinpointKit/Sources/PinpointKit+ShakePresentation.swift
@@ -20,7 +20,7 @@ extension PinpointKit: ShakeDetectingWindowDelegate {
             return
         }
         
-        show(fromViewController: viewController)
+        show(from: viewController)
     }
 }
 

--- a/PinpointKit/PinpointKit/Sources/PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/PinpointKit.swift
@@ -56,7 +56,7 @@ extension PinpointKit: FeedbackCollectorDelegate {
     
     public func feedbackCollector(_ feedbackCollector: FeedbackCollector, didCollect feedback: Feedback) {
         delegate?.pinpointKit(self, willSend: feedback)
-        configuration.sender.sendFeedback(feedback, fromViewController: feedbackCollector.viewController)
+        configuration.sender.send(feedback, from: feedbackCollector.viewController)
     }
 }
 

--- a/PinpointKit/PinpointKit/Sources/PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/PinpointKit.swift
@@ -42,7 +42,7 @@ public class PinpointKit {
      
      - parameter viewController: The view controller from which to present.
      */
-    public func show(fromViewController viewController: UIViewController) {
+    public func show(from viewController: UIViewController) {
         let screenshot = Screenshotter.takeScreenshot()
         displayingViewController = viewController
         

--- a/PinpointKit/PinpointKit/Sources/ScreenshotDetector.swift
+++ b/PinpointKit/PinpointKit/Sources/ScreenshotDetector.swift
@@ -89,7 +89,7 @@ public class ScreenshotDetector: NSObject {
     }
     
     private func succeed(with image: UIImage) {
-        delegate?.screenshotDetector(self, didDetectScreenshot: image)
+        delegate?.screenshotDetector(self, didDetect: image)
     }
     
     private func fail(with error: Error) {
@@ -108,7 +108,7 @@ protocol ScreenshotDetectorDelegate: class {
      - parameter screenshotDetector: The detector responsible for the message.
      - parameter screenshot:         The screeenshot that was detected.
      */
-    func screenshotDetector(_ screenshotDetector: ScreenshotDetector, didDetectScreenshot screenshot: UIImage)
+    func screenshotDetector(_ screenshotDetector: ScreenshotDetector, didDetect screenshot: UIImage)
     
     /**
      Notifies the delegate that the detector failed to detect a screenshot.

--- a/PinpointKit/PinpointKit/Sources/ScreenshotDetector.swift
+++ b/PinpointKit/PinpointKit/Sources/ScreenshotDetector.swift
@@ -97,16 +97,16 @@ public class ScreenshotDetector: NSObject {
     }
 }
 
-/// A protocol that `ScreenshotDetector` uses to inform its delegate of sucessful and failed screenshot detection events.
+/// A protocol that `ScreenshotDetector` uses to inform its delegate of successful and failed screenshot detection events.
 
 @available(iOS 9.0, *)
 protocol ScreenshotDetectorDelegate: class {
     
     /**
-     Notifies the delegate that the detector did sucessfully detect a screenshot.
+     Notifies the delegate that the detector did successfully detect a screenshot.
      
      - parameter screenshotDetector: The detector responsible for the message.
-     - parameter screenshot:         The screeenshot that was detected.
+     - parameter screenshot:         The screenshot that was detected.
      */
     func screenshotDetector(_ screenshotDetector: ScreenshotDetector, didDetect screenshot: UIImage)
     
@@ -114,7 +114,7 @@ protocol ScreenshotDetectorDelegate: class {
      Notifies the delegate that the detector failed to detect a screenshot.
      
      - parameter screenshotDetector: The detector responsible for the message.
-     - parameter error:              The error that occurred while attempting to detecting the screenshot.
+     - parameter error:              The error that occurred while attempting to detect the screenshot.
      */
     func screenshotDetector(_ screenshotDetector: ScreenshotDetector, didFailWith error: ScreenshotDetector.Error)
 }

--- a/PinpointKit/PinpointKit/Sources/ScreenshotDetector.swift
+++ b/PinpointKit/PinpointKit/Sources/ScreenshotDetector.swift
@@ -93,7 +93,7 @@ public class ScreenshotDetector: NSObject {
     }
     
     private func fail(with error: Error) {
-        delegate?.screenshotDetector(self, didFailWithError: error)
+        delegate?.screenshotDetector(self, didFailWith: error)
     }
 }
 
@@ -116,7 +116,7 @@ protocol ScreenshotDetectorDelegate: class {
      - parameter screenshotDetector: The detector responsible for the message.
      - parameter error:              The error that occurred while attempting to detecting the screenshot.
      */
-    func screenshotDetector(_ screenshotDetector: ScreenshotDetector, didFailWithError error: ScreenshotDetector.Error)
+    func screenshotDetector(_ screenshotDetector: ScreenshotDetector, didFailWith error: ScreenshotDetector.Error)
 }
 
 @available(iOS 9.0, *)

--- a/PinpointKit/PinpointKit/Sources/Screenshotter.swift
+++ b/PinpointKit/PinpointKit/Sources/Screenshotter.swift
@@ -12,14 +12,14 @@ import Foundation
 public class Screenshotter {
 
     /**
-     Takes and returns a screenshot of all of an `application`’s windows displayed on a given screen.
+     Takes and returns a screenshot of all of an application’s windows displayed on a given screen.
      
      - parameter screen:      The screen to determine the screenshot size.
      - parameter application: The application to screenshot.
      
      - returns: A screenshot as a `UIImage`.
      */
-    public static func takeScreenshot(_ screen: UIScreen = UIScreen.main(), application: UIApplication = UIApplication.shared()) -> UIImage {
+    public static func takeScreenshot(of screen: UIScreen = UIScreen.main(), in application: UIApplication = UIApplication.shared()) -> UIImage {
         UIGraphicsBeginImageContextWithOptions(screen.bounds.size, true, 0)
         
         application.windows.forEach { window in

--- a/PinpointKit/PinpointKit/Sources/Screenshotter.swift
+++ b/PinpointKit/PinpointKit/Sources/Screenshotter.swift
@@ -14,12 +14,12 @@ public class Screenshotter {
     /**
      Takes and returns a screenshot of all of an application’s windows displayed on a given screen.
      
-     - parameter screen:      The screen to determine the screenshot size.
      - parameter application: The application to screenshot.
+     - parameter screen:      The screen to determine the screenshot size.
      
      - returns: A screenshot as a `UIImage`.
      */
-    public static func takeScreenshot(of screen: UIScreen = UIScreen.main(), in application: UIApplication = UIApplication.shared()) -> UIImage {
+    public static func takeScreenshot(of application: UIApplication = UIApplication.shared(), on screen: UIScreen = UIScreen.main()) -> UIImage {
         UIGraphicsBeginImageContextWithOptions(screen.bounds.size, true, 0)
         
         application.windows.forEach { window in

--- a/PinpointKit/PinpointKit/Sources/Sender.swift
+++ b/PinpointKit/PinpointKit/Sources/Sender.swift
@@ -20,11 +20,12 @@ public protocol Sender: class {
      - parameter feedback:       The feedback to send.
      - parameter viewController: The view controller from which to present any of the sender’s necessary views.
      */
-    func sendFeedback(_ feedback: Feedback, fromViewController viewController: UIViewController?)
+    func send(_ feedback: Feedback, from viewController: UIViewController?)
 }
 
 /// A delegate protocol describing an object that receives success and failure events from a `Sender`.
 public protocol SenderDelegate: class {    
+    
     /**
      Notifies the receiver that the sender successfully sent the feedback with a given type of success.
      

--- a/PinpointKit/PinpointKit/Sources/TextAnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/TextAnnotationView.swift
@@ -80,10 +80,10 @@ public class TextAnnotationView: AnnotationView, UITextViewDelegate {
         
     // MARK: - AnnotationView
     
-    override func moveControlPoints(_ translation: CGPoint) {
+    override func move(controlPointsBy translationAmount: CGPoint) {
         textView.frame = {
             var textViewFrame = self.textView.frame
-            textViewFrame.origin = CGPoint(x: textViewFrame.minX + translation.x, y: textViewFrame.minY + translation.y)
+            textViewFrame.origin = CGPoint(x: textViewFrame.minX + translationAmount.x, y: textViewFrame.minY + translationAmount.y)
             return textViewFrame
         }()
     }

--- a/PinpointKit/PinpointKit/Sources/TextAnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/TextAnnotationView.swift
@@ -106,7 +106,7 @@ public class TextAnnotationView: AnnotationView, UITextViewDelegate {
     }
     
     private var font: UIFont {
-        return UITextView.whenContained(inInstancesOfClasses: [TextAnnotationView.self]).font ?? UIFont.systemFont(ofSize: 32)
+        return UITextView.whenContained(inInstancesOfClasses: [TextAnnotationView.self]).font ?? .systemFont(ofSize: 32)
     }
     
     /// The minimum text size for the annotation view.

--- a/PinpointKit/PinpointKit/Sources/UIColor+Palette.swift
+++ b/PinpointKit/PinpointKit/Sources/UIColor+Palette.swift
@@ -16,7 +16,7 @@ public extension UIColor {
      
      - returns: The Pinpoint specific orange color.
      */
-    static func pinpointOrangeColor() -> UIColor {
+    static func pinpointOrange() -> UIColor {
         return UIColor(red: 1, green: 0.2196, blue: 0.0392, alpha: 1)
     }
 }


### PR DESCRIPTION
📝 Pointed at `swift-3.0`.
~~📝 Based on #132, please review that first.~~

This completes my full project + example project pass for Swift 3.0. A follow-up PR will be based on this one for running the Swift 3 migrator on Xcode 8 beta 2. If you check out this branch to review, please use Xcode 8 beta 1.

Related:

- https://developer.apple.com/videos/play/wwdc2016/403/
- https://swift.org/documentation/api-design-guidelines/