### PR TITLE
Allow Customizing Feedback

### DIFF
--- a/Example/PinpointKitExample/ViewController.swift
+++ b/Example/PinpointKitExample/ViewController.swift
@@ -11,7 +11,7 @@ import PinpointKit
 
 final class ViewController: UITableViewController {
     
-    private let pinpointKit = PinpointKit(configuration: Configuration(sender: MySender(), feedbackRecipients: ["feedback@example.com"]))
+    private let pinpointKit = PinpointKit(feedbackRecipients: ["feedback@example.com"])
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -24,19 +24,5 @@ final class ViewController: UITableViewController {
         super.viewDidAppear(animated)
         
         pinpointKit.show(fromViewController: self)
-    }
-}
-
-final class MySender: MailSender {
-    
-    override func sendFeedback(feedback: Feedback, fromViewController viewController: UIViewController?) {
-        var newFeedback = feedback
-        newFeedback.title = "hello"
-        newFeedback.body = "this is the body of the feedback"
-        newFeedback.screenshotFileName = "my feedback"
-        newFeedback.additionalInformation = ["user": "mliberatore"]
-        newFeedback.logsFileName = "myLogs"
-        
-        super.sendFeedback(newFeedback, fromViewController: viewController)
     }
 }

--- a/Example/PinpointKitExample/ViewController.swift
+++ b/Example/PinpointKitExample/ViewController.swift
@@ -11,7 +11,7 @@ import PinpointKit
 
 final class ViewController: UITableViewController {
     
-    private let pinpointKit = PinpointKit(feedbackRecipients: ["feedback@example.com"])
+    private let pinpointKit = PinpointKit(configuration: Configuration(sender: MySender(), feedbackRecipients: ["feedback@example.com"]))
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -24,5 +24,19 @@ final class ViewController: UITableViewController {
         super.viewDidAppear(animated)
         
         pinpointKit.show(fromViewController: self)
+    }
+}
+
+final class MySender: MailSender {
+    
+    override func sendFeedback(feedback: Feedback, fromViewController viewController: UIViewController?) {
+        var newFeedback = feedback
+        newFeedback.title = "hello"
+        newFeedback.body = "this is the body of the feedback"
+        newFeedback.screenshotFileName = "my feedback"
+        newFeedback.additionalInformation = ["user": "mliberatore"]
+        newFeedback.logsFileName = "myLogs"
+        
+        super.sendFeedback(newFeedback, fromViewController: viewController)
     }
 }

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		475B3ACDE2B25B16097F8FD10645A926 /* BasicLogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CC4696A751768B9105D5565B68C3DB /* BasicLogViewController.swift */; };
 		497847DAB395437D5D11CEBA42705280 /* FeedbackNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D1CAFDC8EA2D8703C0C6EE29E4BF08 /* FeedbackNavigationController.swift */; };
 		4AAEFBB95D4BEDFA82C236B80573C825 /* Annotations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D762474867E802650DD20E294750CF9 /* Annotations.swift */; };
+		4C53FBF91D304C39009EDC4E /* FeedbackConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C53FBF81D304C39009EDC4E /* FeedbackConfiguration.swift */; };
 		50A95E93DED4283192EBFF3DC62B9211 /* StrokeLayoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BAE808FC0873920E02EBCD77AD9FA43 /* StrokeLayoutManager.swift */; };
 		54AFDAD8B333D569BE25A6BF091AA987 /* SourceSansPro-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 93FA706115160440E9256964E66FA57D /* SourceSansPro-Bold.ttf */; };
 		595BB86A2C0B9F6BF072D43298E1442F /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4307288F72B971AF1C34C59718AF3B32 /* Configuration.swift */; };
@@ -106,6 +107,7 @@
 		4307288F72B971AF1C34C59718AF3B32 /* Configuration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		46808D8DD82EBD9B48A30EB1E7344CF1 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		46B1CD047C1B63EF67F23CAC1806889A /* EditorDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EditorDelegate.swift; sourceTree = "<group>"; };
+		4C53FBF81D304C39009EDC4E /* FeedbackConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedbackConfiguration.swift; sourceTree = "<group>"; };
 		4F026C9460FBD43D5F04EF65D2FB5362 /* ArrowAnnotationView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ArrowAnnotationView.swift; sourceTree = "<group>"; };
 		6207788D80D5F34F8E7DB00DE24A8F3E /* PinpointKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "PinpointKit-dummy.m"; sourceTree = "<group>"; };
 		624639227B49043215FCD240C6AC0F95 /* PinpointKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PinpointKit.xcconfig; sourceTree = "<group>"; };
@@ -244,6 +246,7 @@
 				A746927132FD9B70272F614430C08EA6 /* BoxAnnotationView.swift */,
 				A56326EAEA58486DF118DDF5FACD210D /* CheckmarkCell.swift */,
 				4307288F72B971AF1C34C59718AF3B32 /* Configuration.swift */,
+				4C53FBF81D304C39009EDC4E /* FeedbackConfiguration.swift */,
 				DEF610D46B4270498BF110D72EA7ACF8 /* Feedback.swift */,
 				421EAA998DAEFE3DD043FD4FDC40CA43 /* FeedbackCollector.swift */,
 				67D1CAFDC8EA2D8703C0C6EE29E4BF08 /* FeedbackNavigationController.swift */,
@@ -539,6 +542,7 @@
 				151F2A9C1F7BC634B583654EEADB2676 /* MailSender.swift in Sources */,
 				C7F53858824968A2D584C2F34ADBCCDE /* MIMEType.swift in Sources */,
 				A20259EDEFDB840DA0D529030FFA58B0 /* NavigationController.swift in Sources */,
+				4C53FBF91D304C39009EDC4E /* FeedbackConfiguration.swift in Sources */,
 				431AAD1F47EB8C0CF5E6249CC813424F /* NSBundle+PinpointKit.swift in Sources */,
 				30F586F105FF6DC58A6451A4763F10DF /* PinpointKit+ShakePresentation.swift in Sources */,
 				B90600A5C292DF97239C0E7EC3DB0C2B /* PinpointKit-dummy.m in Sources */,

--- a/PinpointKit/PinpointKit/Sources/Configuration.swift
+++ b/PinpointKit/PinpointKit/Sources/Configuration.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-
 /// Encapsulates configuration information for the behavior and appearance of PinpointKit.
 public struct Configuration {
     
@@ -44,14 +43,14 @@ public struct Configuration {
     /**
      Initializes a `Configuration` object with optionally customizable appearance and behaviors.
      
-     - parameter appearance:         A struct containing information about the appearance of displayed components.
-     - parameter interfaceText:      The text to be displayed in the interface.
-     - parameter logCollector:       An optional type that collects logs to be displayed and sent with feedback.
-     - parameter logViewer:          An optional type the shows logs.
-     - parameter feedbackCollector:  A feedback collector that obtains the feedback, by default in the form of annotated screenshots, to send.
-     - parameter editor:             An editor that allows annotation of images.
-     - parameter sender:             A sender that allows sending the feedback outside the framework.
-     - parameter feedbackRecipients: The recipients of the feedback submission. Suitable for email recipients in the "To:" field.
+     - parameter appearance:            A struct containing information about the appearance of displayed components.
+     - parameter interfaceText:         The text to be displayed in the interface.
+     - parameter logCollector:          An optional type that collects logs to be displayed and sent with feedback.
+     - parameter logViewer:             An optional type the shows logs.
+     - parameter feedbackCollector:     A feedback collector that obtains the feedback, by default in the form of annotated screenshots, to send.
+     - parameter editor:                An editor that allows annotation of images.
+     - parameter sender:                A sender that allows sending the feedback outside the framework.
+     - parameter feedbackConfiguration: Configuration properties for all feedback to be sent.
      */
     public init(appearance: InterfaceCustomization.Appearance = InterfaceCustomization.Appearance(),
                 interfaceText: InterfaceCustomization.InterfaceText = InterfaceCustomization.InterfaceText(),
@@ -60,7 +59,7 @@ public struct Configuration {
                 feedbackCollector: FeedbackCollector = FeedbackNavigationController(),
                 editor: Editor = EditImageViewController(),
                 sender: Sender = MailSender(),
-                feedbackRecipients: [String]) {
+                feedbackConfiguration: FeedbackConfiguration) {
         self.feedbackCollector = feedbackCollector
         self.editor = editor
         
@@ -75,6 +74,6 @@ public struct Configuration {
         self.feedbackCollector.logViewer = logViewer
         self.feedbackCollector.logViewer?.interfaceCustomization = interfaceCustomization
         self.feedbackCollector.editor?.interfaceCustomization = interfaceCustomization
-        self.feedbackCollector.feedbackRecipients = feedbackRecipients
+        self.feedbackCollector.feedbackConfiguration = feedbackConfiguration
     }
 }

--- a/PinpointKit/PinpointKit/Sources/Feedback.swift
+++ b/PinpointKit/PinpointKit/Sources/Feedback.swift
@@ -57,25 +57,25 @@ public struct Feedback {
     let screenshot: ScreenshotType
     
     /// A file name without an extension for the screenshot or annotated screenshot.
-    let screenshotFileName: String
+    public var screenshotFileName: String
     
     /// The recipients of the feedback submission. Suitable for email recipients in the "To:" field.
-    let recipients: [String]?
+    var recipients: [String]?
     
     /// A short, optional title of the feedback submission. Suitable for an email subject.
-    let title: String?
+    public var title: String?
     
     /// An optional plain-text body of the feedback submission. Suitable for an email body.
-    let body: String?
+    public var body: String?
     
     /// An optional collection of log strings.
     let logs: [String]?
     
     /// A file name without an extension for the logs text file.
-    let logsFileName: String
+    public var logsFileName: String
     
     /// A dictionary of additional information provided by the application developer.
-    let additionalInformation: [String: AnyObject]?
+    public var additionalInformation: [String: AnyObject]?
     
     /// A struct containing information about the application and its environment.
     let applicationInformation: ApplicationInformation?

--- a/PinpointKit/PinpointKit/Sources/Feedback.swift
+++ b/PinpointKit/PinpointKit/Sources/Feedback.swift
@@ -56,60 +56,30 @@ public struct Feedback {
     /// A screenshot of the screen the feedback relates to.
     let screenshot: ScreenshotType
     
-    /// A file name without an extension for the screenshot or annotated screenshot.
-    public var screenshotFileName: String
-    
-    /// The recipients of the feedback submission. Suitable for email recipients in the "To:" field.
-    public var recipients: [String]?
-    
-    /// A short, optional title of the feedback submission. Suitable for an email subject.
-    public var title: String?
-    
-    /// An optional plain-text body of the feedback submission. Suitable for an email body.
-    public var body: String?
-    
     /// An optional collection of log strings.
     let logs: [String]?
     
-    /// A file name without an extension for the logs text file.
-    public var logsFileName: String
-    
-    /// A dictionary of additional information provided by the application developer.
-    public var additionalInformation: [String: AnyObject]?
-    
     /// A struct containing information about the application and its environment.
     let applicationInformation: ApplicationInformation?
+    
+    /// Specifies configurable properties for feedback.
+    public var configuration: FeedbackConfiguration?
     
     /**
      Initializes a `Feedback` with optional default values.
      
      - parameter screenshot:             The type of screenshot in the feedback.
-     - parameter screenshotFileName:     The file name of the screenshot.
-     - parameter recipients:             The recipients of the feedback submission.
-     - parameter title:                  The title of the feedback.
-     - parameter body:                   The default body text.
      - parameter logs:                   The logs to include in the feedback, if any.
-     - parameter logsFileName:           The file name of the logs text file.
-     - parameter additionalInformation:  Any additional information you want to capture.
      - parameter applicationInformation: Information about the application to be captured.
+     - parameter configuration:          Configurable properties for feedback.
      */
     init(screenshot: ScreenshotType,
-        screenshotFileName: String = "Screenshot",
-        recipients: [String]? = nil,
-        title: String? = "Bug Report",
-        body: String? = nil,
         logs: [String]? = nil,
-        logsFileName: String = "logs",
-        additionalInformation: [String: AnyObject]? = nil,
-        applicationInformation: ApplicationInformation? = nil) {
+        applicationInformation: ApplicationInformation? = nil,
+        configuration: FeedbackConfiguration? = nil) {
             self.screenshot = screenshot
-            self.screenshotFileName = screenshotFileName
-            self.recipients = recipients
-            self.title = title
-            self.body = body
             self.logs = logs
-            self.logsFileName = logsFileName
-            self.additionalInformation = additionalInformation
             self.applicationInformation = applicationInformation
+            self.configuration = configuration
     }
 }

--- a/PinpointKit/PinpointKit/Sources/Feedback.swift
+++ b/PinpointKit/PinpointKit/Sources/Feedback.swift
@@ -60,7 +60,7 @@ public struct Feedback {
     public var screenshotFileName: String
     
     /// The recipients of the feedback submission. Suitable for email recipients in the "To:" field.
-    var recipients: [String]?
+    public var recipients: [String]?
     
     /// A short, optional title of the feedback submission. Suitable for an email subject.
     public var title: String?

--- a/PinpointKit/PinpointKit/Sources/FeedbackCollector.swift
+++ b/PinpointKit/PinpointKit/Sources/FeedbackCollector.swift
@@ -12,8 +12,8 @@ public protocol FeedbackCollector: class, LogSupporting, InterfaceCustomizable {
     /// A delegate that is informed of significant events in feedback collection.
     weak var feedbackDelegate: FeedbackCollectorDelegate? { get set }
     
-    /// The recipients of the feedback submission. Suitable for email recipients in the "To:" field.
-    var feedbackRecipients: [String]? { get set }
+    /// Configuration properties for all feedback to be sent.
+    var feedbackConfiguration: FeedbackConfiguration? { get set }
     
     /// The view controller that displays the feedback to collect.
     var viewController: UIViewController { get }

--- a/PinpointKit/PinpointKit/Sources/FeedbackConfiguration.swift
+++ b/PinpointKit/PinpointKit/Sources/FeedbackConfiguration.swift
@@ -9,6 +9,9 @@
 /// Encapsulates configuration properties for all feedback to be sent.
 public struct FeedbackConfiguration {
     
+    /// The value of the default parameter for `title in the initializer.
+    public static let DefaultTitle = "Bug Report"
+    
     /// A file name without an extension for the screenshot or annotated screenshot.
     public var screenshotFileName: String
     
@@ -39,7 +42,7 @@ public struct FeedbackConfiguration {
      */
     public init(screenshotFileName: String = "Screenshot",
                 recipients: [String],
-                title: String? = "Bug Report",
+                title: String? = FeedbackConfiguration.DefaultTitle,
                 body: String? = nil,
                 logsFileName: String = "logs",
                 additionalInformation: [String: AnyObject]? = nil) {

--- a/PinpointKit/PinpointKit/Sources/FeedbackConfiguration.swift
+++ b/PinpointKit/PinpointKit/Sources/FeedbackConfiguration.swift
@@ -9,7 +9,7 @@
 /// Encapsulates configuration properties for all feedback to be sent.
 public struct FeedbackConfiguration {
     
-    /// The value of the default parameter for `title in the initializer.
+    /// The value of the default parameter for `title` in the initializer.
     public static let DefaultTitle = "Bug Report"
     
     /// A file name without an extension for the screenshot or annotated screenshot.

--- a/PinpointKit/PinpointKit/Sources/FeedbackConfiguration.swift
+++ b/PinpointKit/PinpointKit/Sources/FeedbackConfiguration.swift
@@ -1,0 +1,53 @@
+//
+//  FeedbackConfiguration.swift
+//  Pods
+//
+//  Created by Michael Liberatore on 7/8/16.
+//
+//
+
+/// Encapsulates configuration properties for all feedback to be sent.
+public struct FeedbackConfiguration {
+    
+    /// A file name without an extension for the screenshot or annotated screenshot.
+    public var screenshotFileName: String
+    
+    /// The recipients of the feedback submission. Suitable for email recipients in the "To:" field.
+    public var recipients: [String]?
+    
+    /// A short, optional title of the feedback submission. Suitable for an email subject.
+    public var title: String?
+    
+    /// An optional plain-text body of the feedback submission. Suitable for an email body.
+    public var body: String?
+    
+    /// A file name without an extension for the logs text file.
+    public var logsFileName: String
+    
+    /// A dictionary of additional information provided by the application developer.
+    public var additionalInformation: [String: AnyObject]?
+    
+    /**
+     Initializes a `FeedbackConfiguration` with optional default values.
+     
+     - parameter screenshotFileName:     The file name of the screenshot.
+     - parameter recipients:             The recipients of the feedback submission.
+     - parameter title:                  The title of the feedback.
+     - parameter body:                   The default body text.
+     - parameter logsFileName:           The file name of the logs text file.
+     - parameter additionalInformation:  Any additional information you want to capture.
+     */
+    public init(screenshotFileName: String = "Screenshot",
+                recipients: [String],
+                title: String? = "Bug Report",
+                body: String? = nil,
+                logsFileName: String = "logs",
+                additionalInformation: [String: AnyObject]? = nil) {
+        self.screenshotFileName = screenshotFileName
+        self.recipients = recipients
+        self.title = title
+        self.body = body
+        self.logsFileName = logsFileName
+        self.additionalInformation = additionalInformation
+    }
+}

--- a/PinpointKit/PinpointKit/Sources/FeedbackNavigationController.swift
+++ b/PinpointKit/PinpointKit/Sources/FeedbackNavigationController.swift
@@ -54,12 +54,12 @@ public final class FeedbackNavigationController: UINavigationController, Feedbac
         }
     }
     
-    public var feedbackRecipients: [String]? {
+    public var feedbackConfiguration: FeedbackConfiguration? {
         get {
-            return feedbackViewController.feedbackRecipients
+            return feedbackViewController.feedbackConfiguration
         }
         set {
-            feedbackViewController.feedbackRecipients = newValue
+            feedbackViewController.feedbackConfiguration = newValue
         }
     }
     

--- a/PinpointKit/PinpointKit/Sources/FeedbackViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/FeedbackViewController.swift
@@ -30,7 +30,7 @@ public final class FeedbackViewController: UITableViewController {
     // MARK: - FeedbackCollector
     
     public weak var feedbackDelegate: FeedbackCollectorDelegate?
-    public var feedbackRecipients: [String]?
+    public var feedbackConfiguration: FeedbackConfiguration?
     
     // MARK: - FeedbackViewController
     
@@ -167,9 +167,9 @@ public final class FeedbackViewController: UITableViewController {
         let feedback: Feedback?
         
         if let screenshot = annotatedScreenshot {
-            feedback = Feedback(screenshot: .Annotated(image: screenshot), recipients: feedbackRecipients, logs: logs)
+            feedback = Feedback(screenshot: .Annotated(image: screenshot), logs: logs, configuration: feedbackConfiguration)
         } else if let screenshot = screenshot {
-            feedback = Feedback(screenshot: .Original(image: screenshot), recipients: feedbackRecipients, logs: logs)
+            feedback = Feedback(screenshot: .Original(image: screenshot), logs: logs, configuration: feedbackConfiguration)
         } else {
             feedback = nil
         }

--- a/PinpointKit/PinpointKit/Sources/MailSender.swift
+++ b/PinpointKit/PinpointKit/Sources/MailSender.swift
@@ -96,23 +96,23 @@ public class MailSender: NSObject, Sender {
 private extension MFMailComposeViewController {
     
     func attachFeedback(feedback: Feedback) throws {
-        setToRecipients(feedback.recipients)
+        setToRecipients(feedback.configuration?.recipients)
         
-        if let subject = feedback.title {
+        if let subject = feedback.configuration?.title {
             setSubject(subject)
         }
         
-        if let body = feedback.body {
+        if let body = feedback.configuration?.body {
            setMessageBody(body, isHTML: false)
         }
         
-        try attachScreenshot(feedback.screenshot, screenshotFileName: feedback.screenshotFileName)
+        try attachScreenshot(feedback.screenshot, screenshotFileName: feedback.configuration?.screenshotFileName ?? "Screenshot")
         
         if let logs = feedback.logs {
-            try attachLogs(logs, logsFileName: feedback.logsFileName)
+            try attachLogs(logs, logsFileName: feedback.configuration?.logsFileName ?? "logs")
         }
         
-        if let additionalInformation = feedback.additionalInformation {
+        if let additionalInformation = feedback.configuration?.additionalInformation {
             attachAdditionalInformation(additionalInformation)
         }
     }

--- a/PinpointKit/PinpointKit/Sources/PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/PinpointKit.swift
@@ -41,7 +41,8 @@ public class PinpointKit {
      - parameter delegate:           A delegate that is notified of significant events.
      */
     public convenience init(feedbackRecipients: [String], delegate: PinpointKitDelegate? = nil) {
-        let configuration = Configuration(feedbackRecipients: feedbackRecipients)
+        let feedbackConfiguration = FeedbackConfiguration(recipients: feedbackRecipients)
+        let configuration = Configuration(feedbackConfiguration: feedbackConfiguration)
         
         self.init(configuration: configuration, delegate: delegate)
     }

--- a/PinpointKit/PinpointKit/Sources/PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/PinpointKit.swift
@@ -38,10 +38,12 @@ public class PinpointKit {
      Initializes a `PinpointKit` with a default configuration supplied with feedback recipients and an optional delegate.
      
      - parameter feedbackRecipients: The recipients of the feedback submission. Suitable for email recipients in the "To:" field.
+     - parameter title:              The default title of the feedback.
+     - parameter body:               The default body text of the feedback.
      - parameter delegate:           A delegate that is notified of significant events.
      */
-    public convenience init(feedbackRecipients: [String], delegate: PinpointKitDelegate? = nil) {
-        let feedbackConfiguration = FeedbackConfiguration(recipients: feedbackRecipients)
+    public convenience init(feedbackRecipients: [String], title: String? = FeedbackConfiguration.DefaultTitle, body: String? = nil, delegate: PinpointKitDelegate? = nil) {
+        let feedbackConfiguration = FeedbackConfiguration(recipients: feedbackRecipients, title: title, body: body)
         let configuration = Configuration(feedbackConfiguration: feedbackConfiguration)
         
         self.init(configuration: configuration, delegate: delegate)


### PR DESCRIPTION
Closes #134 by allowing the customization of `Feedback`’s `body` and `title`.

To test with a sample subclass, run `git revert -n e9403c8` in Terminal and see the incorporation of `MySender` in `ViewController.swift`.

This PR makes a few properties on `Feedback` `public var`s instead of `let`s. This allows for interception / copying / modifying of `Feedback` by subclassing `MailSender` as seen in 93b9f71. I’d like to open the discussion on alternatives though, as I don’t think making the developer subclass is necessarily the most ideal solution to specifying an email subject and body.

#### Pros

- Simple for developer to implement.
- Allows for up-to-the-moment variation in feedback data, such as `additionalInformation`, as opposed to another solution in which more feedback information would be specified up front in `Configuration`, which would be static if you wanted to initialize `PinpointKit` only once.

#### Cons

- Requires inheritance for a fairly basic customization.
- Mix of some feedback details being specified up front (i.e. `feedbackRecipients`) and others at the time of sending. Maybe we should consider a `FeedbackConfiguration` struct instead of passing `feedbackRecipients` only through `PinpointKit` and `Configuration` initializers. Having only that as a solution, though, still doesn’t allow for up-to-the-moment variation (see the pro above).