### PR TITLE
Ability to pass a custom screenshot into pinpointKit.show function

### DIFF
--- a/PinpointKit/PinpointKit/Sources/PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/PinpointKit.swift
@@ -50,9 +50,9 @@ public class PinpointKit {
      Shows PinpointKit’s feedback collection UI from a given view controller.
      
      - parameter viewController: The view controller from which to present.
+     - parameter screenshot: The screenshot associated with the bug report.
      */
-    public func show(fromViewController viewController: UIViewController) {
-        let screenshot = Screenshotter.takeScreenshot()
+    public func show(fromViewController viewController: UIViewController, screenshot: UIImage = Screenshotter.takeScreenshot()) {
         displayingViewController = viewController
         
         configuration.feedbackCollector.collectFeedbackWithScreenshot(screenshot, fromViewController: viewController)


### PR DESCRIPTION
Added the ability to pass an optional custom screenshot into the `show(..)` function.

The issue:
- I'm using both [SwiftTweaks](https://github.com/Khan/SwiftTweaks) and [PinpointKit](https://github.com/Lickability/PinpointKit).
- I have a custom window that appears when a motion shake is detected. It shows a table view which has two options: one option to take the user to the `SwiftTweaks` while the other option is to report a bug via `PinpointKit`.
- If I use `pinpointKit.show(myViewController)` the screenshot will be the undesired table view controller that shows the two options: `SwiftTweaks` and `PinpointKit`.