### PR TITLE
Public access control for Feedback.swift & MIMEType.swift

### DIFF
--- a/PinpointKit/PinpointKit/Sources/Feedback.swift
+++ b/PinpointKit/PinpointKit/Sources/Feedback.swift
@@ -12,7 +12,7 @@ import UIKit
 public struct Feedback {
     
     /// An enum with assocated values that represents the screenshot.
-    enum ScreenshotType {
+    public enum ScreenshotType {
         /// The original, un-annotated screenshot.
         case Original(image: UIImage)
         
@@ -23,7 +23,7 @@ public struct Feedback {
         case Combined(originalImage: UIImage, annotatedImage: UIImage)
         
         /// Returns an image of the screenshot preferring the annotated image.
-        var preferredImage: UIImage {
+        public var preferredImage: UIImage {
             switch self {
             case let Original(image):
                 return image
@@ -36,49 +36,49 @@ public struct Feedback {
     }
     
     /// A substructure containing information about the application and its environment.
-    struct ApplicationInformation {
+    public struct ApplicationInformation {
         /// The application’s marketing version.
-        let version: String?
+        public let version: String?
         
         /// The application’s build number.
-        let build: String?
+        public let build: String?
         
         /// The application’s display name.
-        let name: String?
+        public let name: String?
         
         /// The application’s bundle identifer.
-        let bundleIdentifer: String?
+        public let bundleIdentifer: String?
         
         /// The operating system version of the OS in which the application is running.
-        let operatingSystemVersion: NSOperatingSystemVersion?
+        public let operatingSystemVersion: NSOperatingSystemVersion?
     }
     
     /// A screenshot of the screen the feedback relates to.
-    let screenshot: ScreenshotType
+    public let screenshot: ScreenshotType
     
     /// A file name without an extension for the screenshot or annotated screenshot.
-    let screenshotFileName: String
+    public let screenshotFileName: String
     
     /// The recipients of the feedback submission. Suitable for email recipients in the "To:" field.
-    let recipients: [String]?
+    public let recipients: [String]?
     
     /// A short, optional title of the feedback submission. Suitable for an email subject.
-    let title: String?
+    public let title: String?
     
     /// An optional plain-text body of the feedback submission. Suitable for an email body.
-    let body: String?
+    public let body: String?
     
     /// An optional collection of log strings.
-    let logs: [String]?
+    public let logs: [String]?
     
     /// A file name without an extension for the logs text file.
-    let logsFileName: String
+    public let logsFileName: String
     
     /// A dictionary of additional information provided by the application developer.
-    let additionalInformation: [String: AnyObject]?
+    public let additionalInformation: [String: AnyObject]?
     
     /// A struct containing information about the application and its environment.
-    let applicationInformation: ApplicationInformation?
+    public let applicationInformation: ApplicationInformation?
     
     /**
      Initializes a `Feedback` with optional default values.
@@ -94,22 +94,22 @@ public struct Feedback {
      - parameter applicationInformation: Information about the application to be captured.
      */
     init(screenshot: ScreenshotType,
-        screenshotFileName: String = "Screenshot",
-        recipients: [String]? = nil,
-        title: String? = "Bug Report",
-        body: String? = nil,
-        logs: [String]? = nil,
-        logsFileName: String = "logs",
-        additionalInformation: [String: AnyObject]? = nil,
-        applicationInformation: ApplicationInformation? = nil) {
-            self.screenshot = screenshot
-            self.screenshotFileName = screenshotFileName
-            self.recipients = recipients
-            self.title = title
-            self.body = body
-            self.logs = logs
-            self.logsFileName = logsFileName
-            self.additionalInformation = additionalInformation
-            self.applicationInformation = applicationInformation
+         screenshotFileName: String = "Screenshot",
+         recipients: [String]? = nil,
+         title: String? = "Bug Report",
+         body: String? = nil,
+         logs: [String]? = nil,
+         logsFileName: String = "logs",
+         additionalInformation: [String: AnyObject]? = nil,
+         applicationInformation: ApplicationInformation? = nil) {
+        self.screenshot = screenshot
+        self.screenshotFileName = screenshotFileName
+        self.recipients = recipients
+        self.title = title
+        self.body = body
+        self.logs = logs
+        self.logsFileName = logsFileName
+        self.additionalInformation = additionalInformation
+        self.applicationInformation = applicationInformation
     }
 }

--- a/PinpointKit/PinpointKit/Sources/MIMEType.swift
+++ b/PinpointKit/PinpointKit/Sources/MIMEType.swift
@@ -7,7 +7,7 @@
 //
 
 /// An enumeration of MIME types used in PinpointKit.
-enum MIMEType: String {
+public enum MIMEType: String {
     
     /// The MIME type used to represent a Portable Network Graphics image.
     case PNG = "image/png"
@@ -19,7 +19,7 @@ enum MIMEType: String {
     case JSON = "application/json"
     
     /// The file extension associated with the MIME type including the leading `.`.
-    var fileExtension: String {
+    public var fileExtension: String {
         switch self {
         case PNG:
             return ".png"


### PR DESCRIPTION
Needed access to some of the internal variables in Feedback.swift and MIMEType.swift when creating my custom `Sender` type.