### PR TITLE
Mentions Swift 2.3 and 3.0 Branches in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 * iOS 9.0+
 * Xcode 7.3+
 
-> **Note:** Branches for Swift 2.3 ([`swift-2.3`](https://github.com/Lickability/PinpointKit/tree/swift-2.3)) and 3.0 ([`swift-3.0`](https://github.com/Lickability/PinpointKit/tree/swift-3.0)) are being kept up to date as Xcode 8 betas are released.
+> **Note:** Branches for Swift 2.3 ([`swift-2.3`](https://github.com/Lickability/PinpointKit/tree/swift-2.3)) and 3.0 ([`swift-3.0`](https://github.com/Lickability/PinpointKit/tree/swift-3.0)) are being kept up-to-date as Xcode 8 betas are released.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@
 * iOS 9.0+
 * Xcode 7.3+
 
+> Note: Branches for Swift 2.3 ([`swift-2.3`](https://github.com/Lickability/PinpointKit/tree/swift-2.3)) and 3.0 ([`swift-3.0`](https://github.com/Lickability/PinpointKit/tree/swift-3.0)) are being kept up to date as Xcode 8 betas are released.
+
 ## Installation
 
 ### CocoaPods

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 * iOS 9.0+
 * Xcode 7.3+
 
-> Note: Branches for Swift 2.3 ([`swift-2.3`](https://github.com/Lickability/PinpointKit/tree/swift-2.3)) and 3.0 ([`swift-3.0`](https://github.com/Lickability/PinpointKit/tree/swift-3.0)) are being kept up to date as Xcode 8 betas are released.
+> **Note:** Branches for Swift 2.3 ([`swift-2.3`](https://github.com/Lickability/PinpointKit/tree/swift-2.3)) and 3.0 ([`swift-3.0`](https://github.com/Lickability/PinpointKit/tree/swift-3.0)) are being kept up to date as Xcode 8 betas are released.
 
 ## Installation
 


### PR DESCRIPTION
As the title suggests, this change makes mention of the new Swift branches in the README within the **Requirements** section as proposed in #123.

Feedback / change requests welcome.