### PR TITLE
Adding annotationTextAttributes to InterfaceCustomization

### DIFF
--- a/PinpointKit/PinpointKit/Sources/BarButtonItem.swift
+++ b/PinpointKit/PinpointKit/Sources/BarButtonItem.swift
@@ -14,12 +14,16 @@ extension UIBarButtonItem {
      Convenience initializer for creating a “Done” `UIBarButtonItem` with a specified target, action, and font.
      
      - parameter target: The bar button item’s target.
+     - parameter title:  The bar button item’s title.
      - parameter font:   The font of the bar button item’s title.
      - parameter action: The bar button item’s action.
      */
-    convenience init(doneButtonWithTarget target: AnyObject?, font: UIFont, action: Selector) {
-        self.init(barButtonSystemItem: .Done, target: target, action: action)
-        
+    convenience init(doneButtonWithTarget target: AnyObject?, title: String? = nil, font: UIFont, action: Selector) {
+        if let title = title {
+            self.init(title: title, style: .Done, target: target, action: action)
+        } else {
+            self.init(barButtonSystemItem: .Done, target: target, action: action)
+        }
         setTitleTextAttributes([NSFontAttributeName: font], forState: .Normal)
     }
 }

--- a/PinpointKit/PinpointKit/Sources/BarButtonItem.swift
+++ b/PinpointKit/PinpointKit/Sources/BarButtonItem.swift
@@ -18,12 +18,8 @@ extension UIBarButtonItem {
      - parameter font:   The font of the bar button item’s title.
      - parameter action: The bar button item’s action.
      */
-    convenience init(doneButtonWithTarget target: AnyObject?, title: String? = nil, font: UIFont, action: Selector) {
-        if let title = title {
-            self.init(title: title, style: .Done, target: target, action: action)
-        } else {
-            self.init(barButtonSystemItem: .Done, target: target, action: action)
-        }
+    convenience init(doneButtonWithTarget target: AnyObject?, title: String, font: UIFont, action: Selector) {
+        self.init(title: title, style: .Done, target: target, action: action)
         setTitleTextAttributes([NSFontAttributeName: font], forState: .Normal)
     }
 }

--- a/PinpointKit/PinpointKit/Sources/Editing/AnnotationViewFactory.swift
+++ b/PinpointKit/PinpointKit/Sources/Editing/AnnotationViewFactory.swift
@@ -21,6 +21,9 @@ struct AnnotationViewFactory {
     /// The stroke color of the annotation.
     let strokeColor: UIColor
     
+    /// The text attributes of the annotation.
+    let textAttributes: [String: AnyObject]
+    
     /**
      Constructs an annotation view.
      
@@ -38,6 +41,7 @@ struct AnnotationViewFactory {
             return view
         case .Text:
             let view = TextAnnotationView()
+            view.textAttributes = textAttributes
             let minimumSize = view.minimumTextSize
             let endLocation = CGPoint(x: currentLocation.x + minimumSize.width, y: currentLocation.y + minimumSize.height)
             view.annotation = Annotation(startLocation: currentLocation, endLocation: endLocation, strokeColor: strokeColor)

--- a/PinpointKit/PinpointKit/Sources/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Editing/EditImageViewController.swift
@@ -93,7 +93,9 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
     
     private lazy var doneBarButtonItem: UIBarButtonItem = {
         guard let doneButtonFont = self.interfaceCustomization?.appearance.editorTextAnnotationDoneButtonFont else { assertionFailure(); return UIBarButtonItem() }
-        return UIBarButtonItem(doneButtonWithTarget: self, title: self.interfaceCustomization?.interfaceText.textEditingDoneButtonTitle, font: doneButtonFont, action: #selector(EditImageViewController.doneButtonTapped(_:)))
+        guard let doneButtonTitle = self.interfaceCustomization?.interfaceText.textEditingDoneButtonTitle else {
+            assertionFailure(); return UIBarButtonItem() }
+        return UIBarButtonItem(doneButtonWithTarget: self, title: doneButtonTitle, font: doneButtonFont, action: #selector(EditImageViewController.doneButtonTapped(_:)))
     }()
     
     private var currentTool: Tool? {
@@ -450,7 +452,8 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
     private func updateInterfaceCustomization() {
         guard let appearance = interfaceCustomization?.appearance else { assertionFailure(); return }
         segmentedControl.setTitleTextAttributes([NSFontAttributeName: appearance.editorTextAnnotationSegmentFont], forState: UIControlState.Normal)
-        UITextView.appearanceWhenContainedInInstancesOfClasses([TextAnnotationView.self]).font = appearance.editorTextAnnotationFont
+        guard let annotationFont = appearance.annotationTextAttributes[NSFontAttributeName] as? UIFont else { assertionFailure(); return }
+        UITextView.appearanceWhenContainedInInstancesOfClasses([TextAnnotationView.self]).font = annotationFont
         
         if let annotationFillColor = appearance.annotationFillColor {
             annotationsView.tintColor = annotationFillColor

--- a/PinpointKit/PinpointKit/Sources/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Editing/EditImageViewController.swift
@@ -93,7 +93,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
     
     private lazy var doneBarButtonItem: UIBarButtonItem = {
         guard let doneButtonFont = self.interfaceCustomization?.appearance.editorTextAnnotationDoneButtonFont else { assertionFailure(); return UIBarButtonItem() }
-        return UIBarButtonItem(doneButtonWithTarget: self, font: doneButtonFont, action: #selector(EditImageViewController.doneButtonTapped(_:)))
+        return UIBarButtonItem(doneButtonWithTarget: self, title: self.interfaceCustomization?.interfaceText.textEditingDoneButtonTitle, font: doneButtonFont, action: #selector(EditImageViewController.doneButtonTapped(_:)))
     }()
     
     private var currentTool: Tool? {

--- a/PinpointKit/PinpointKit/Sources/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Editing/EditImageViewController.swift
@@ -454,7 +454,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         
         if let annotationFillColor = appearance.annotationFillColor {
             annotationsView.tintColor = annotationFillColor
-        }
+        }        
     }
     
     // MARK: - Create annotations
@@ -475,10 +475,11 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
     private func handleCreateAnnotationGestureRecognizerBegan(gestureRecognizer: UIGestureRecognizer) {
         guard let currentTool = currentTool else { return }
         guard let annotationStrokeColor = interfaceCustomization?.appearance.annotationStrokeColor else { return }
+        guard let annotationTextAttributes = interfaceCustomization?.appearance.annotationTextAttributes else { return }
         
         let currentLocation = gestureRecognizer.locationInView(annotationsView)
         
-        let factory = AnnotationViewFactory(image: imageView.image?.CGImage, currentLocation: currentLocation, tool: currentTool, strokeColor: annotationStrokeColor)
+        let factory = AnnotationViewFactory(image: imageView.image?.CGImage, currentLocation: currentLocation, tool: currentTool, strokeColor: annotationStrokeColor, textAttributes: annotationTextAttributes)
         
         let view: AnnotationView = factory.annotationView()
         

--- a/PinpointKit/PinpointKit/Sources/InterfaceCustomization.swift
+++ b/PinpointKit/PinpointKit/Sources/InterfaceCustomization.swift
@@ -62,10 +62,7 @@ public struct InterfaceCustomization {
         
         /// The font used for the text annotation tool segment in the editor.
         let editorTextAnnotationSegmentFont: UIFont
-        
-        /// The font used for text annotations in the editor.
-        let editorTextAnnotationFont: UIFont
-        
+                
         /// The font used for the done button in the editor displayed while editing a text annotation.
         let editorTextAnnotationDoneButtonFont: UIFont
         
@@ -84,7 +81,6 @@ public struct InterfaceCustomization {
          - parameter logCollectionPermissionFont:        The font used for the title of the cell that allows the user to toggle log collection.
          - parameter logFont:                            The font used for displaying logs.
          - parameter editorTextAnnotationSegmentFont:    The font used for the text annotation tool segment in the editor.
-         - parameter editorTextAnnotationFont:           The font used for text annotations in the editor.
          - parameter editorTextAnnotationDoneButtonFont: The font used for the done button in the editor displayed while editing a text annotation.
          */
         public init(tintColor: UIColor? = UIColor.pinpointOrangeColor(),
@@ -99,28 +95,34 @@ public struct InterfaceCustomization {
                     logCollectionPermissionFont: UIFont = .sourceSansProFontOfSize(19),
                     logFont: UIFont = .menloRegularFontOfSize(10),
                     editorTextAnnotationSegmentFont: UIFont = .sourceSansProFontOfSize(18),
-                    editorTextAnnotationFont: UIFont = .sourceSansProFontOfSize(32, weight: .Semibold),
                     editorTextAnnotationDoneButtonFont: UIFont = .sourceSansProFontOfSize(19, weight: .Semibold)) {
             self.tintColor = tintColor
             self.annotationFillColor = annotationFillColor
             self.annotationStrokeColor = annotationStrokeColor
+            
+            // Default annotation text attributes
+            var defaultAnnotationTextAttributes = [String: AnyObject]()
+            let shadow = NSShadow()
+            shadow.shadowBlurRadius = 5
+            shadow.shadowColor = UIColor(white: 0.0, alpha: 1.0)
+            shadow.shadowOffset = CGSize.zero
+            defaultAnnotationTextAttributes[NSFontAttributeName] = UIFont.sourceSansProFontOfSize(32, weight: .Semibold)
+            defaultAnnotationTextAttributes[NSForegroundColorAttributeName] = annotationStrokeColor
+            defaultAnnotationTextAttributes[NSShadowAttributeName] = shadow
+            defaultAnnotationTextAttributes[NSKernAttributeName] = 1.3
+                
+            // Custom annotation text attributes
             if let annotationTextAttributes = annotationTextAttributes {
-                self.annotationTextAttributes = annotationTextAttributes
-            } else {
-                var textAttributes: [String: AnyObject] {
-                    let shadow = NSShadow()
-                    shadow.shadowBlurRadius = 5
-                    shadow.shadowColor = UIColor(white: 0.0, alpha: 1.0)
-                    shadow.shadowOffset = CGSize.zero
-                    
-                    return [
-                        NSForegroundColorAttributeName: annotationStrokeColor,
-                        NSShadowAttributeName: shadow,
-                        NSKernAttributeName: 1.3
-                    ]
+                var customAnnotationTextAttributes = annotationTextAttributes
+                // Ensure annotation font is set, if not use default font
+                if annotationTextAttributes[NSFontAttributeName] == nil {
+                    customAnnotationTextAttributes[NSFontAttributeName] = defaultAnnotationTextAttributes[NSFontAttributeName]
                 }
-                self.annotationTextAttributes = textAttributes
+                self.annotationTextAttributes = customAnnotationTextAttributes
+            } else {
+                self.annotationTextAttributes = defaultAnnotationTextAttributes
             }
+            
             self.logFont = logFont
             self.navigationTitleFont = navigationTitleFont
             self.feedbackSendButtonFont = feedbackSendButtonFont
@@ -129,7 +131,6 @@ public struct InterfaceCustomization {
             self.feedbackBackButtonFont = feedbackBackButtonFont
             self.logCollectionPermissionFont = logCollectionPermissionFont
             self.editorTextAnnotationSegmentFont = editorTextAnnotationSegmentFont
-            self.editorTextAnnotationFont = editorTextAnnotationFont
             self.editorTextAnnotationDoneButtonFont = editorTextAnnotationDoneButtonFont
         }
     }

--- a/PinpointKit/PinpointKit/Sources/InterfaceCustomization.swift
+++ b/PinpointKit/PinpointKit/Sources/InterfaceCustomization.swift
@@ -162,6 +162,9 @@ public struct InterfaceCustomization {
         
         ///  The title of a button that cancels text editing.
         let textEditingDismissButtonTitle: String
+
+        ///  The title of a button that cancels text editing.
+        let textEditingDoneButtonTitle: String
         
         /**
          Initializes an `InterfaceText` with custom values, using a default if a particular property is unspecified.
@@ -174,6 +177,7 @@ public struct InterfaceCustomization {
          - parameter logCollectorTitle:             The title of the log collector.
          - parameter logCollectionPermissionTitle:  The title of the permission button.
          - parameter textEditingDismissButtonTitle: The title of the text editing dismiss button.
+         - parameter textEditingDoneButtonTitle:    The title of the text editing done button.
          */
         public init(feedbackCollectorTitle: String? = NSLocalizedString("Report a Bug", comment: "Title of a view that reports a bug"),
                     feedbackSendButtonTitle: String = NSLocalizedString("Send", comment: "A button that sends feedback."),
@@ -182,7 +186,8 @@ public struct InterfaceCustomization {
                     feedbackEditHint: String? = NSLocalizedString("Tap the screenshot to annotate.", comment: "A hint on how to edit the screenshot"),
                     logCollectorTitle: String? = NSLocalizedString("Console Log", comment: "Title of a view that collects logs"),
                     logCollectionPermissionTitle: String = NSLocalizedString("Include Console Log", comment: "Title of a button asking the user to include system logs"),
-                    textEditingDismissButtonTitle: String = NSLocalizedString("Dismiss", comment: "Title of a button that dismisses text editing")) {
+                    textEditingDismissButtonTitle: String = NSLocalizedString("Dismiss", comment: "Title of a button that dismisses text editing"),
+                    textEditingDoneButtonTitle: String = NSLocalizedString("Done", comment: "Title of a button that finish editing")) {
             self.feedbackCollectorTitle = feedbackCollectorTitle
             self.feedbackSendButtonTitle = feedbackSendButtonTitle
             self.feedbackCancelButtonTitle = feedbackCancelButtonTitle
@@ -191,6 +196,7 @@ public struct InterfaceCustomization {
             self.logCollectorTitle = logCollectorTitle
             self.logCollectionPermissionTitle = logCollectionPermissionTitle
             self.textEditingDismissButtonTitle = textEditingDismissButtonTitle
+            self.textEditingDoneButtonTitle = textEditingDoneButtonTitle
         }
     }
 }

--- a/PinpointKit/PinpointKit/Sources/InterfaceCustomization.swift
+++ b/PinpointKit/PinpointKit/Sources/InterfaceCustomization.swift
@@ -33,6 +33,9 @@ public struct InterfaceCustomization {
         /// The fill color for annotations. If none is supplied, the `tintColor` of the relevant view will be used.
         let annotationFillColor: UIColor?
         
+        /// The text attributes for annotations.
+        let annotationTextAttributes: [String: AnyObject]
+        
         /// The stroke color for annotations.
         let annotationStrokeColor: UIColor
         
@@ -72,6 +75,7 @@ public struct InterfaceCustomization {
          - parameter tintColor:                          The tint color of the interface.
          - parameter annotationFillColor:                The fill color for annotations. If none is supplied, the `tintColor` of the relevant view will be used.
          - parameter annotationStrokeColor:              The stroke color for annotations.
+         - parameter annotationTextAttributes:           The text attributes for annotations.
          - parameter navigationTitleFont:                The font used for navigation titles.
          - parameter feedbackSendButtonFont:             The font used for the button that sends feedback.
          - parameter feedbackCancelButtonFont:           The font used for the button that cancels feedback collection.
@@ -86,6 +90,7 @@ public struct InterfaceCustomization {
         public init(tintColor: UIColor? = UIColor.pinpointOrangeColor(),
                     annotationFillColor: UIColor? = nil,
                     annotationStrokeColor: UIColor = .whiteColor(),
+                    annotationTextAttributes: [String: AnyObject]? = nil,
                     navigationTitleFont: UIFont = .sourceSansProFontOfSize(19, weight: .Semibold),
                     feedbackSendButtonFont: UIFont = .sourceSansProFontOfSize(19, weight: .Semibold),
                     feedbackCancelButtonFont: UIFont = .sourceSansProFontOfSize(19),
@@ -99,6 +104,23 @@ public struct InterfaceCustomization {
             self.tintColor = tintColor
             self.annotationFillColor = annotationFillColor
             self.annotationStrokeColor = annotationStrokeColor
+            if let annotationTextAttributes = annotationTextAttributes {
+                self.annotationTextAttributes = annotationTextAttributes
+            } else {
+                var textAttributes: [String: AnyObject] {
+                    let shadow = NSShadow()
+                    shadow.shadowBlurRadius = 5
+                    shadow.shadowColor = UIColor(white: 0.0, alpha: 1.0)
+                    shadow.shadowOffset = CGSize.zero
+                    
+                    return [
+                        NSForegroundColorAttributeName: annotationStrokeColor,
+                        NSShadowAttributeName: shadow,
+                        NSKernAttributeName: 1.3
+                    ]
+                }
+                self.annotationTextAttributes = textAttributes
+            }
             self.logFont = logFont
             self.navigationTitleFont = navigationTitleFont
             self.feedbackSendButtonFont = feedbackSendButtonFont

--- a/PinpointKit/PinpointKit/Sources/TextAnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/TextAnnotationView.swift
@@ -91,18 +91,11 @@ public class TextAnnotationView: AnnotationView, UITextViewDelegate {
     // MARK: - TextAnnotationView
     
     /// The attributes of the text to use for an `NSAttributedString`.
-    var textAttributes: [String: AnyObject] {
-        let shadow = NSShadow()
-        shadow.shadowBlurRadius = 5
-        shadow.shadowColor = UIColor(white: 0.0, alpha: 1.0)
-        shadow.shadowOffset = CGSize.zero
-        
-        return [
-            NSFontAttributeName: font,
-            NSForegroundColorAttributeName: tintColor,
-            NSShadowAttributeName: shadow,
-            NSKernAttributeName: 1.3
-        ]
+    var textAttributes: [String: AnyObject] = [:] {
+        didSet {
+            textAttributes[NSFontAttributeName] = font
+            textView.typingAttributes = textAttributes
+        }
     }
     
     private var font: UIFont {


### PR DESCRIPTION
Adding annotationTextAttributes to InterfaceCustomization. In our case used to disable the shadow for a Text Annotation.

*Update*: Adding textEditingDoneButton to InterfaceCustomization Struct