### PR TITLE
Doesn’t Assume `FeedbackViewController` is Presented Modally

### DIFF
--- a/PinpointKit/PinpointKit/Sources/FeedbackViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/FeedbackViewController.swift
@@ -185,13 +185,12 @@ public final class FeedbackViewController: UITableViewController {
     }
     
     @objc private func cancelButtonTapped() {
-        if presentingViewController != nil {
-            dismissViewControllerAnimated(true, completion: nil)
-        } else if let navigationController = navigationController where navigationController.topViewController == self && navigationController.viewControllers.count > 1 {
-            navigationController.popViewControllerAnimated(true)
-        } else {
+        guard presentingViewController != nil else {
             assertionFailure("Attempting to dismiss `FeedbackViewController` in unexpected presentation context.")
+            return
         }
+        
+        dismissViewControllerAnimated(true, completion: nil)
     }
 }
 

--- a/PinpointKit/PinpointKit/Sources/FeedbackViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/FeedbackViewController.swift
@@ -82,7 +82,6 @@ public final class FeedbackViewController: UITableViewController {
     public override func viewDidLoad() {
         super.viewDidLoad()
         editor?.delegate = self
-        updateInterfaceCustomization()
     }
     
     public override func viewWillAppear(animated: Bool) {
@@ -90,6 +89,7 @@ public final class FeedbackViewController: UITableViewController {
         
         // Since this view controller could be reused in another orientation, update the table header view on every appearance to reflect the current orientation sizing.
         updateTableHeaderView()
+        updateInterfaceCustomization()
     }
     
     public override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
@@ -153,7 +153,12 @@ public final class FeedbackViewController: UITableViewController {
         }
         
         cancelBarButtonItem.setTitleTextAttributes([NSFontAttributeName: appearance.feedbackCancelButtonFont], forState: .Normal)
-        navigationItem.leftBarButtonItem = cancelBarButtonItem
+        
+        if viewController.presentingViewController != nil {
+            navigationItem.leftBarButtonItem = cancelBarButtonItem
+        } else {
+            navigationItem.leftBarButtonItem = nil
+        }
         
         view.tintColor = appearance.tintColor
         updateTableHeaderView()
@@ -179,8 +184,14 @@ public final class FeedbackViewController: UITableViewController {
         feedbackDelegate?.feedbackCollector(self, didCollectFeedback: feedbackToSend)
     }
     
-    @objc private func cancelButtonTapped() {        
-        dismissViewControllerAnimated(true, completion: nil)
+    @objc private func cancelButtonTapped() {
+        if presentingViewController != nil {
+            dismissViewControllerAnimated(true, completion: nil)
+        } else if let navigationController = navigationController where navigationController.topViewController == self && navigationController.viewControllers.count > 1 {
+            navigationController.popViewControllerAnimated(true)
+        } else {
+            assertionFailure("Attempting to dismiss `FeedbackViewController` in unexpected presentation context.")
+        }
     }
 }
 

--- a/PinpointKit/PinpointKit/Sources/FeedbackViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/FeedbackViewController.swift
@@ -154,7 +154,7 @@ public final class FeedbackViewController: UITableViewController {
         
         cancelBarButtonItem.setTitleTextAttributes([NSFontAttributeName: appearance.feedbackCancelButtonFont], forState: .Normal)
         
-        if viewController.presentingViewController != nil {
+        if presentingViewController != nil {
             navigationItem.leftBarButtonItem = cancelBarButtonItem
         } else {
             navigationItem.leftBarButtonItem = nil

--- a/PinpointKit/PinpointKit/Sources/PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/PinpointKit.swift
@@ -58,7 +58,13 @@ public class PinpointKit {
         let screenshot = Screenshotter.takeScreenshot()
         displayingViewController = viewController
         
-        configuration.feedbackCollector.collectFeedbackWithScreenshot(screenshot, fromViewController: viewController)
+        if let feedbackNavigationController = configuration.feedbackCollector as? FeedbackNavigationController {
+            feedbackNavigationController.feedbackViewController.screenshot = screenshot
+            viewController.navigationController?.view.tintColor = feedbackNavigationController.interfaceCustomization?.appearance.tintColor
+            viewController.navigationController?.pushViewController(feedbackNavigationController.feedbackViewController, animated: true)
+        }
+        
+        //configuration.feedbackCollector.collectFeedbackWithScreenshot(screenshot, fromViewController: viewController)
     }
 }
 

--- a/PinpointKit/PinpointKit/Sources/PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/PinpointKit.swift
@@ -58,13 +58,7 @@ public class PinpointKit {
         let screenshot = Screenshotter.takeScreenshot()
         displayingViewController = viewController
         
-        if let feedbackNavigationController = configuration.feedbackCollector as? FeedbackNavigationController {
-            feedbackNavigationController.feedbackViewController.screenshot = screenshot
-            viewController.navigationController?.view.tintColor = feedbackNavigationController.interfaceCustomization?.appearance.tintColor
-            viewController.navigationController?.pushViewController(feedbackNavigationController.feedbackViewController, animated: true)
-        }
-        
-        //configuration.feedbackCollector.collectFeedbackWithScreenshot(screenshot, fromViewController: viewController)
+        configuration.feedbackCollector.collectFeedbackWithScreenshot(screenshot, fromViewController: viewController)
     }
 }
 


### PR DESCRIPTION
Closes #92 

Now, if you push instead of present `FeedbackViewController`, it’ll have a normal back button instead of a dismiss button.