### PR TITLE
Follow Up to Adding `annotationTextAttributes` to InterfaceCustomization

### DIFF
--- a/PinpointKit/PinpointKit/Sources/Configuration.swift
+++ b/PinpointKit/PinpointKit/Sources/Configuration.swift
@@ -52,7 +52,7 @@ public struct Configuration {
      - parameter sender:                A sender that allows sending the feedback outside the framework.
      - parameter feedbackConfiguration: Configuration properties for all feedback to be sent.
      */
-    public init(appearance: InterfaceCustomization.Appearance = InterfaceCustomization.Appearance(),
+    public init(appearance: InterfaceCustomization.Appearance = InterfaceCustomization.customAppearance,
                 interfaceText: InterfaceCustomization.InterfaceText = InterfaceCustomization.InterfaceText(),
                 logCollector: LogCollector? = SystemLogCollector(),
                 logViewer: LogViewer? = BasicLogViewController(),

--- a/PinpointKit/PinpointKit/Sources/Configuration.swift
+++ b/PinpointKit/PinpointKit/Sources/Configuration.swift
@@ -52,7 +52,7 @@ public struct Configuration {
      - parameter sender:                A sender that allows sending the feedback outside the framework.
      - parameter feedbackConfiguration: Configuration properties for all feedback to be sent.
      */
-    public init(appearance: InterfaceCustomization.Appearance = InterfaceCustomization.customAppearance,
+    public init(appearance: InterfaceCustomization.Appearance = InterfaceCustomization.Appearance(),
                 interfaceText: InterfaceCustomization.InterfaceText = InterfaceCustomization.InterfaceText(),
                 logCollector: LogCollector? = SystemLogCollector(),
                 logViewer: LogViewer? = BasicLogViewController(),

--- a/PinpointKit/PinpointKit/Sources/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Editing/EditImageViewController.swift
@@ -456,7 +456,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         
         if let annotationFillColor = appearance.annotationFillColor {
             annotationsView.tintColor = annotationFillColor
-        }        
+        }
     }
     
     // MARK: - Create annotations

--- a/PinpointKit/PinpointKit/Sources/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Editing/EditImageViewController.swift
@@ -93,8 +93,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
     
     private lazy var doneBarButtonItem: UIBarButtonItem = {
         guard let doneButtonFont = self.interfaceCustomization?.appearance.editorTextAnnotationDoneButtonFont else { assertionFailure(); return UIBarButtonItem() }
-        guard let doneButtonTitle = self.interfaceCustomization?.interfaceText.textEditingDoneButtonTitle else {
-            assertionFailure(); return UIBarButtonItem() }
+        guard let doneButtonTitle = self.interfaceCustomization?.interfaceText.textEditingDoneButtonTitle else { assertionFailure(); return UIBarButtonItem() }
         return UIBarButtonItem(doneButtonWithTarget: self, title: doneButtonTitle, font: doneButtonFont, action: #selector(EditImageViewController.doneButtonTapped(_:)))
     }()
     

--- a/PinpointKit/PinpointKit/Sources/InterfaceCustomization.swift
+++ b/PinpointKit/PinpointKit/Sources/InterfaceCustomization.swift
@@ -33,7 +33,7 @@ public struct InterfaceCustomization {
         /// The fill color for annotations. If none is supplied, the `tintColor` of the relevant view will be used.
         let annotationFillColor: UIColor?
         
-        /// The text attributes for annotations.
+        /// The text attributes for annotations. Note that `NSForegroundColorAttributeName` can only be customized using `annotationFillColor`.
         let annotationTextAttributes: [String: AnyObject]
         
         /// The stroke color for annotations.
@@ -108,7 +108,7 @@ public struct InterfaceCustomization {
                 }
                 self.annotationTextAttributes = customAnnotationTextAttributes
             } else {
-                self.annotationTextAttributes = self.dynamicType.defaultTextAnnotationAttributes(withTextColor: annotationStrokeColor)
+                self.annotationTextAttributes = self.dynamicType.defaultTextAnnotationAttributes
             }
             
             self.logFont = logFont
@@ -192,14 +192,13 @@ public struct InterfaceCustomization {
 
 private extension InterfaceCustomization.Appearance {
     
-    static func defaultTextAnnotationAttributes(withTextColor textColor: UIColor) -> [String: AnyObject] {
+    static var defaultTextAnnotationAttributes: [String: AnyObject] {
         let shadow = NSShadow()
         shadow.shadowBlurRadius = 5
         shadow.shadowColor = UIColor.blackColor()
         shadow.shadowOffset = .zero
 
         return [NSFontAttributeName: DefaultAnnotationTextFont,
-                NSForegroundColorAttributeName: textColor,
                 NSShadowAttributeName: shadow,
                 NSKernAttributeName: 1.3]
     }

--- a/PinpointKit/PinpointKit/Sources/InterfaceCustomization.swift
+++ b/PinpointKit/PinpointKit/Sources/InterfaceCustomization.swift
@@ -62,7 +62,7 @@ public struct InterfaceCustomization {
         
         /// The font used for the text annotation tool segment in the editor.
         let editorTextAnnotationSegmentFont: UIFont
-                
+        
         /// The font used for the done button in the editor displayed while editing a text annotation.
         let editorTextAnnotationDoneButtonFont: UIFont
         
@@ -110,7 +110,7 @@ public struct InterfaceCustomization {
             defaultAnnotationTextAttributes[NSForegroundColorAttributeName] = annotationStrokeColor
             defaultAnnotationTextAttributes[NSShadowAttributeName] = shadow
             defaultAnnotationTextAttributes[NSKernAttributeName] = 1.3
-                
+            
             // Custom annotation text attributes
             if let annotationTextAttributes = annotationTextAttributes {
                 var customAnnotationTextAttributes = annotationTextAttributes
@@ -163,7 +163,7 @@ public struct InterfaceCustomization {
         
         ///  The title of a button that cancels text editing.
         let textEditingDismissButtonTitle: String
-
+        
         ///  The title of a button that cancels text editing.
         let textEditingDoneButtonTitle: String
         

--- a/PinpointKit/PinpointKit/Sources/InterfaceCustomization.swift
+++ b/PinpointKit/PinpointKit/Sources/InterfaceCustomization.swift
@@ -100,27 +100,15 @@ public struct InterfaceCustomization {
             self.annotationFillColor = annotationFillColor
             self.annotationStrokeColor = annotationStrokeColor
             
-            // Default annotation text attributes
-            var defaultAnnotationTextAttributes = [String: AnyObject]()
-            let shadow = NSShadow()
-            shadow.shadowBlurRadius = 5
-            shadow.shadowColor = UIColor(white: 0.0, alpha: 1.0)
-            shadow.shadowOffset = CGSize.zero
-            defaultAnnotationTextAttributes[NSFontAttributeName] = UIFont.sourceSansProFontOfSize(32, weight: .Semibold)
-            defaultAnnotationTextAttributes[NSForegroundColorAttributeName] = annotationStrokeColor
-            defaultAnnotationTextAttributes[NSShadowAttributeName] = shadow
-            defaultAnnotationTextAttributes[NSKernAttributeName] = 1.3
-            
             // Custom annotation text attributes
-            if let annotationTextAttributes = annotationTextAttributes {
-                var customAnnotationTextAttributes = annotationTextAttributes
+            if var customAnnotationTextAttributes = annotationTextAttributes {
                 // Ensure annotation font is set, if not use default font
-                if annotationTextAttributes[NSFontAttributeName] == nil {
-                    customAnnotationTextAttributes[NSFontAttributeName] = defaultAnnotationTextAttributes[NSFontAttributeName]
+                if customAnnotationTextAttributes[NSFontAttributeName] == nil {
+                    customAnnotationTextAttributes[NSFontAttributeName] = self.dynamicType.DefaultAnnotationTextFont
                 }
                 self.annotationTextAttributes = customAnnotationTextAttributes
             } else {
-                self.annotationTextAttributes = defaultAnnotationTextAttributes
+                self.annotationTextAttributes = self.dynamicType.defaultTextAnnotationAttributes(withTextColor: annotationStrokeColor)
             }
             
             self.logFont = logFont
@@ -200,4 +188,21 @@ public struct InterfaceCustomization {
             self.textEditingDoneButtonTitle = textEditingDoneButtonTitle
         }
     }
+}
+
+private extension InterfaceCustomization.Appearance {
+    
+    static func defaultTextAnnotationAttributes(withTextColor textColor: UIColor) -> [String: AnyObject] {
+        let shadow = NSShadow()
+        shadow.shadowBlurRadius = 5
+        shadow.shadowColor = UIColor.blackColor()
+        shadow.shadowOffset = .zero
+
+        return [NSFontAttributeName: DefaultAnnotationTextFont,
+                NSForegroundColorAttributeName: textColor,
+                NSShadowAttributeName: shadow,
+                NSKernAttributeName: 1.3]
+    }
+    
+    static let DefaultAnnotationTextFont = UIFont.sourceSansProFontOfSize(32, weight: .Semibold)
 }

--- a/PinpointKit/PinpointKit/Sources/InterfaceCustomization.swift
+++ b/PinpointKit/PinpointKit/Sources/InterfaceCustomization.swift
@@ -11,6 +11,23 @@ public struct InterfaceCustomization {
     let interfaceText: InterfaceText
     let appearance: Appearance
     
+    static let customAppearance = Appearance(tintColor: .greenColor(),
+                                             annotationFillColor: .yellowColor(),
+                                             annotationStrokeColor: .grayColor(),
+                                             annotationTextAttributes: [
+                                                NSFontAttributeName: UIFont.sourceSansProFontOfSize(60),
+                                                NSBackgroundColorAttributeName: UIColor.greenColor()
+                                             ],
+                                             navigationTitleFont: .sourceSansProFontOfSize(10),
+                                             feedbackSendButtonFont: .sourceSansProFontOfSize(10),
+                                             feedbackCancelButtonFont: .sourceSansProFontOfSize(10),
+                                             feedbackEditHintFont: .sourceSansProFontOfSize(10),
+                                             feedbackBackButtonFont: .sourceSansProFontOfSize(10),
+                                             logCollectionPermissionFont: .sourceSansProFontOfSize(10),
+                                             logFont: .sourceSansProFontOfSize(10),
+                                             editorTextAnnotationSegmentFont: .sourceSansProFontOfSize(10),
+                                             editorTextAnnotationDoneButtonFont: .sourceSansProFontOfSize(10))
+    
     /**
      Initializes an InterfaceCustomization object.
      

--- a/PinpointKit/PinpointKit/Sources/InterfaceCustomization.swift
+++ b/PinpointKit/PinpointKit/Sources/InterfaceCustomization.swift
@@ -11,23 +11,6 @@ public struct InterfaceCustomization {
     let interfaceText: InterfaceText
     let appearance: Appearance
     
-    static let customAppearance = Appearance(tintColor: .greenColor(),
-                                             annotationFillColor: .yellowColor(),
-                                             annotationStrokeColor: .grayColor(),
-                                             annotationTextAttributes: [
-                                                NSFontAttributeName: UIFont.sourceSansProFontOfSize(60),
-                                                NSBackgroundColorAttributeName: UIColor.greenColor()
-                                             ],
-                                             navigationTitleFont: .sourceSansProFontOfSize(10),
-                                             feedbackSendButtonFont: .sourceSansProFontOfSize(10),
-                                             feedbackCancelButtonFont: .sourceSansProFontOfSize(10),
-                                             feedbackEditHintFont: .sourceSansProFontOfSize(10),
-                                             feedbackBackButtonFont: .sourceSansProFontOfSize(10),
-                                             logCollectionPermissionFont: .sourceSansProFontOfSize(10),
-                                             logFont: .sourceSansProFontOfSize(10),
-                                             editorTextAnnotationSegmentFont: .sourceSansProFontOfSize(10),
-                                             editorTextAnnotationDoneButtonFont: .sourceSansProFontOfSize(10))
-    
     /**
      Initializes an InterfaceCustomization object.
      


### PR DESCRIPTION
Follow up to #148

- Some cleanup / consistency changes
- Moves default text attributes to private extension to reduce logic in `Appearance` initializer
- Adds clarity about `NSForegroundColorAttributeName` value which isn’t respected since we use a single tint color for _all_ annotations, which should all change together when e.g. an alert is presented.

To text text attribute specification: `git revert -n d07354a`
