### PR TITLE
Fixes Gap on FeedbackViewController

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -26,7 +26,7 @@
 		28C00E4BDBE22EB4BBEC9CEEF5BC2DE6 /* CheckmarkCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28F338345D142EFBFB293D525C33A24 /* CheckmarkCell.swift */; };
 		2BF2DDFACD0DAD14A2AABE13E1213119 /* AnnotationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F34DC149C68E3D001FE95ADAB03416 /* AnnotationView.swift */; };
 		2F6D8C4A8D2279A30C4766FD64F9D7CB /* InterfaceCustomization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 227DBC70734B340C20B25880392673A2 /* InterfaceCustomization.swift */; };
-		34194259F73BE7AB550BC1566EE08814 /* ScreenshotHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89C1484541D21C4281BA3ED93971A21 /* ScreenshotHeaderView.swift */; };
+		34194259F73BE7AB550BC1566EE08814 /* ScreenshotCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89C1484541D21C4281BA3ED93971A21 /* ScreenshotCell.swift */; };
 		35F0122E6A12F0BE7C52499E6089D902 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30F5AA4FD467BB51C36043607DA27DA3 /* Configuration.swift */; };
 		392F121A5726514F9E1F9137F4BA3050 /* Fonts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81989FFD3ABDA38A0D39F333101537A9 /* Fonts.swift */; };
 		398B99C91925A9B4E41A5B6EAAC0228F /* PinpointKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1851531A8ED6419FF3F0CE6020D5F12 /* PinpointKit.swift */; };
@@ -134,7 +134,7 @@
 		A0C594DAC52E5B086F8E2DEE8C7280E4 /* Screenshotter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Screenshotter.swift; sourceTree = "<group>"; };
 		A51C66D65E5AF88B6EEEFF7A107D7651 /* FeedbackConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedbackConfiguration.swift; sourceTree = "<group>"; };
 		A671B8F35D77D0BE69BA2C89E87F614F /* SystemLogCollector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SystemLogCollector.swift; sourceTree = "<group>"; };
-		A89C1484541D21C4281BA3ED93971A21 /* ScreenshotHeaderView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScreenshotHeaderView.swift; sourceTree = "<group>"; };
+		A89C1484541D21C4281BA3ED93971A21 /* ScreenshotCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScreenshotCell.swift; sourceTree = "<group>"; };
 		AF882FD6DA5B6EE31D5682A092FC9799 /* ASLLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ASLLogger.m; sourceTree = "<group>"; };
 		B3B899A0B12DE8854651E7B38551B012 /* MessageUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk/System/Library/Frameworks/MessageUI.framework; sourceTree = DEVELOPER_DIR; };
 		BCEF62B55C3639F9F95A136036C883BE /* SourceSansPro-Semibold.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; path = "SourceSansPro-Semibold.ttf"; sourceTree = "<group>"; };
@@ -361,7 +361,7 @@
 				78BE17CC17A940358625098ABA7F70EB /* PinpointKit+ShakePresentation.swift */,
 				D55BACDCA6375FB67E334AD4C239257D /* Screen.swift */,
 				26347F54419B3F4E3467C55160FA800C /* ScreenshotDetector.swift */,
-				A89C1484541D21C4281BA3ED93971A21 /* ScreenshotHeaderView.swift */,
+				A89C1484541D21C4281BA3ED93971A21 /* ScreenshotCell.swift */,
 				A0C594DAC52E5B086F8E2DEE8C7280E4 /* Screenshotter.swift */,
 				8B6FB4763E282677F56C8288F0B396C1 /* Sender.swift */,
 				44ACB9AF788D5E295E169BC7A760A86F /* ShakeDetectingWindow.swift */,
@@ -561,7 +561,7 @@
 				398B99C91925A9B4E41A5B6EAAC0228F /* PinpointKit.swift in Sources */,
 				229383B182F6B754B745B8FCEF71D7D8 /* Screen.swift in Sources */,
 				BBD7301E7AEF029ACFA45662098779B2 /* ScreenshotDetector.swift in Sources */,
-				34194259F73BE7AB550BC1566EE08814 /* ScreenshotHeaderView.swift in Sources */,
+				34194259F73BE7AB550BC1566EE08814 /* ScreenshotCell.swift in Sources */,
 				AEC384A90C20C186F0BE8C7E40C9C6F2 /* Screenshotter.swift in Sources */,
 				E829B409D59574D91BDDE621962DA38F /* Sender.swift in Sources */,
 				C546C94D0D92EBDF865FBAE94476F04D /* ShakeDetectingWindow.swift in Sources */,

--- a/PinpointKit/PinpointKit/Sources/FeedbackTableViewDataSource.swift
+++ b/PinpointKit/PinpointKit/Sources/FeedbackTableViewDataSource.swift
@@ -17,11 +17,12 @@ final class FeedbackTableViewDataSource: NSObject, UITableViewDataSource {
      Initializes the data source with a configuration and a boolean value indicating whether the user has enabled log collection.
      
      - parameter interfaceCustomization:   The interface customization used to set up the data source.
+     - parameter screenshot:               The screenshot to display for annotating.
      - parameter logSupporting:            The object the controls the support of logging.
      - parameter userEnabledLogCollection: A boolean value indicating whether the user has enabled log collection.
      */
-    init(interfaceCustomization: InterfaceCustomization, logSupporting: LogSupporting, userEnabledLogCollection: Bool) {
-        sections = self.dynamicType.sectionsFromConfiguration(interfaceCustomization, logSupporting: logSupporting, userEnabledLogCollection: userEnabledLogCollection)
+    init(interfaceCustomization: InterfaceCustomization, screenshot: UIImage, logSupporting: LogSupporting, userEnabledLogCollection: Bool) {
+        sections = self.dynamicType.sectionsFromConfiguration(interfaceCustomization, screenshot: screenshot, logSupporting: logSupporting, userEnabledLogCollection: userEnabledLogCollection)
     }
     
     private enum Section {
@@ -36,18 +37,51 @@ final class FeedbackTableViewDataSource: NSObject, UITableViewDataSource {
     }
     
     private enum Row {
+        case screenshot(screensot: UIImage, hintText: String?, hintFont: UIFont)
         case collectLogs(enabled: Bool, title: String, font: UIFont, canView: Bool)
     }
     
     // MARK: - FeedbackTableViewDataSource
     
-    private static func sectionsFromConfiguration(_ interfaceCustomization: InterfaceCustomization, logSupporting: LogSupporting, userEnabledLogCollection: Bool) -> [Section] {
+    private static func sectionsFromConfiguration(_ interfaceCustomization: InterfaceCustomization, screenshot: UIImage, logSupporting: LogSupporting, userEnabledLogCollection: Bool) -> [Section] {
         guard logSupporting.logCollector != nil else { return [] }
         
-        let collectLogsRow = Row.collectLogs(enabled: userEnabledLogCollection, title: interfaceCustomization.interfaceText.logCollectionPermissionTitle, font: interfaceCustomization.appearance.logCollectionPermissionFont, canView: logSupporting.logViewer != nil)
-        let feedbackSection = Section.feedback(rows: [collectLogsRow])
+        let screenshotRow = Row.screenshot(screensot: screenshot, hintText: interfaceCustomization.interfaceText.feedbackEditHint, hintFont: interfaceCustomization.appearance.feedbackEditHintFont)
+        let screenshotSection = Section.feedback(rows: [screenshotRow])
         
-        return [feedbackSection]
+        let collectLogsRow = Row.collectLogs(enabled: userEnabledLogCollection, title: interfaceCustomization.interfaceText.logCollectionPermissionTitle, font: interfaceCustomization.appearance.logCollectionPermissionFont, canView: logSupporting.logViewer != nil)
+        let collectLogsSection = Section.feedback(rows: [collectLogsRow])
+        
+        return [screenshotSection, collectLogsSection]
+    }
+    
+    private func checkmarkCell(for row: Row) -> CheckmarkCell {
+        let cell = CheckmarkCell() // TODO: dequeue instead.
+
+        guard case let .collectLogs(enabled, title, font, canView) = row else {
+            assertionFailure("Found unexpected row type when creating checkmark cell.")
+            return cell
+        }
+        
+        cell.textLabel?.text = title
+        cell.textLabel?.font = font
+        cell.accessoryType = canView ? .detailButton : .none
+        cell.isChecked = enabled
+        
+        return cell
+    }
+    
+    private func screenshotCell(for row: Row) -> ScreenshotHeaderView {
+        let cell = ScreenshotHeaderView() // TODO: dequeue instead.
+        
+        guard case let .screenshot(screenshot, hintText, hintFont) = row else {
+            assertionFailure("Found unexpected row type when creating screenshot cell.")
+            return cell
+        }
+        
+        cell.viewModel = ScreenshotHeaderView.ViewModel(screenshot: screenshot, hintText: hintText, hintFont: hintFont)
+        
+        return cell
     }
     
     // MARK: - UITableViewDataSource
@@ -61,22 +95,17 @@ final class FeedbackTableViewDataSource: NSObject, UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = CheckmarkCell()
         let section = sections[indexPath.section]
         
-        switch section {
+        switch sections[indexPath.section] {
         case let .feedback(rows):
             let row = rows[indexPath.row]
-            
             switch row {
-            case let .collectLogs(enabled, title, font, canView):
-                cell.textLabel?.text = title
-                cell.textLabel?.font = font
-                cell.accessoryType = canView ? .detailButton : .none
-                cell.isChecked = enabled
+            case .screenshot:
+                return screenshotCell(for: row)
+            case .collectLogs:
+                return checkmarkCell(for: row)
             }
         }
-        
-        return cell
     }
 }

--- a/PinpointKit/PinpointKit/Sources/FeedbackTableViewDataSource.swift
+++ b/PinpointKit/PinpointKit/Sources/FeedbackTableViewDataSource.swift
@@ -74,15 +74,15 @@ final class FeedbackTableViewDataSource: NSObject, UITableViewDataSource {
         return cell
     }
     
-    private func screenshotCell(for row: Row) -> ScreenshotHeaderView {
-        let cell = ScreenshotHeaderView()
+    private func screenshotCell(for row: Row) -> ScreenshotCell {
+        let cell = ScreenshotCell()
         
         guard case let .screenshot(screenshot, hintText, hintFont) = row else {
             assertionFailure("Found unexpected row type when creating screenshot cell.")
             return cell
         }
         
-        cell.viewModel = ScreenshotHeaderView.ViewModel(screenshot: screenshot, hintText: hintText, hintFont: hintFont)
+        cell.viewModel = ScreenshotCell.ViewModel(screenshot: screenshot, hintText: hintText, hintFont: hintFont)
         cell.screenshotButtonTapHandler = { [weak self] button in
             guard let strongSelf = self else { return }
             

--- a/PinpointKit/PinpointKit/Sources/FeedbackViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/FeedbackViewController.swift
@@ -81,6 +81,10 @@ public final class FeedbackViewController: UITableViewController {
     
     public override func viewDidLoad() {
         super.viewDidLoad()
+        
+        tableView.estimatedRowHeight = 100.0
+        tableView.rowHeight = UITableViewAutomaticDimension
+        
         editor?.delegate = self
     }
     
@@ -105,27 +109,12 @@ public final class FeedbackViewController: UITableViewController {
     
     private func updateDataSource() {
         guard let interfaceCustomization = interfaceCustomization else { assertionFailure(); return }
+        guard let screenshot = screenshot else { assertionFailure(); return }
         
-        dataSource = FeedbackTableViewDataSource(interfaceCustomization: interfaceCustomization, logSupporting: self, userEnabledLogCollection: userEnabledLogCollection)
+        dataSource = FeedbackTableViewDataSource(interfaceCustomization: interfaceCustomization, screenshot: screenshot, logSupporting: self, userEnabledLogCollection: userEnabledLogCollection)
     }
     
     private func updateTableHeaderView() {
-        guard let screenshot = screenshot, editor = editor else { return }
-        let screenshotToDisplay = annotatedScreenshot ?? screenshot
-        
-        // We must set the screenshot before showing the view controller.
-        editor.setScreenshot(screenshot)
-        let header = ScreenshotHeaderView()
-
-        header.viewModel = ScreenshotHeaderView.ViewModel(screenshot: screenshotToDisplay, hintText: interfaceCustomization?.interfaceText.feedbackEditHint, hintFont: interfaceCustomization?.appearance.feedbackEditHintFont)
-        header.screenshotButtonTapHandler = { [weak self] button in
-            let editImageViewController = NavigationController(rootViewController: editor.viewController)
-            editImageViewController.view.tintColor = self?.interfaceCustomization?.appearance.tintColor
-            self?.present(editImageViewController, animated: true, completion: nil)
-        }
-        
-        tableView.tableHeaderView = header
-        tableView.enableTableHeaderViewDynamicHeight()
     }
     
     private func updateInterfaceCustomization() {
@@ -228,6 +217,19 @@ extension FeedbackViewController {
     public override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         userEnabledLogCollection = !userEnabledLogCollection
         tableView.reloadRows(at: [indexPath], with: .automatic)
+    }
+    public override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return .leastNormalMagnitude
+    }
+    
+    public override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        
+        // Only leave space under the last section.
+        if section == tableView.numberOfSections - 1 {
+            return tableView.sectionFooterHeight
+        }
+        
+        return .leastNormalMagnitude
     }
 }
 

--- a/PinpointKit/PinpointKit/Sources/ScreenshotCell.swift
+++ b/PinpointKit/PinpointKit/Sources/ScreenshotCell.swift
@@ -1,5 +1,5 @@
 //
-//  ScreenshotHeaderView.swift
+//  ScreenshotCell.swift
 //  PinpointKit
 //
 //  Created by Matthew Bischoff on 2/19/16.
@@ -9,7 +9,7 @@
 import UIKit
 
 /// A view that displays a screenshot and hint text about how to edit it.
-class ScreenshotHeaderView: UITableViewCell {
+class ScreenshotCell: UITableViewCell {
     
     /// A type of closure that is invoked when a button is tapped.
     typealias TapHandler = (button: UIButton) -> Void
@@ -111,7 +111,7 @@ class ScreenshotHeaderView: UITableViewCell {
         super.addSubview(view)
     }
     
-    // MARK: - ScreenshotHeaderView
+    // MARK: - ScreenshotCell
     
     private func setUp() {
         backgroundColor = .clear
@@ -136,7 +136,7 @@ class ScreenshotHeaderView: UITableViewCell {
         
         screenshotButtonHeightConstraint = screenshotButton.heightAnchor.constraint(equalTo: screenshotButton.widthAnchor, multiplier: 1.0)
         
-        screenshotButton.addTarget(self, action: #selector(ScreenshotHeaderView.screenshotButtonTapped(_:)), for: .touchUpInside)
+        screenshotButton.addTarget(self, action: #selector(ScreenshotCell.screenshotButtonTapped(_:)), for: .touchUpInside)
     }
     
     @objc private func screenshotButtonTapped(_ sender: UIButton) {

--- a/PinpointKit/PinpointKit/Sources/ScreenshotHeaderView.swift
+++ b/PinpointKit/PinpointKit/Sources/ScreenshotHeaderView.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// A view that displays a screenshot and hint text about how to edit it.
-class ScreenshotHeaderView: UIView {
+class ScreenshotHeaderView: UITableViewCell {
     
     /// A type of closure that is invoked when a button is tapped.
     typealias TapHandler = (button: UIButton) -> Void
@@ -81,15 +81,16 @@ class ScreenshotHeaderView: UIView {
         }
     }
     
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    public override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
         
         setUp()
     }
     
-    @available(*, unavailable)
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+    public required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        
+        setUp()
     }
     
     // MARK: - UIView
@@ -100,9 +101,22 @@ class ScreenshotHeaderView: UIView {
         screenshotButton.layer.borderColor = tintColor.cgColor
     }
     
+    override func addSubview(_ view: UIView) {
+        // Prevents the adding of separators to this cell.
+        let separatorHeight = 1.0 / UIScreen.main.scale
+        guard view.frame.height != separatorHeight else {
+            return
+        }
+        
+        super.addSubview(view)
+    }
+    
     // MARK: - ScreenshotHeaderView
     
     private func setUp() {
+        backgroundColor = .clear
+        selectionStyle = .none
+        
         addSubview(stackView)
         
         stackView.topAnchor.constraint(equalTo: topAnchor).isActive = true


### PR DESCRIPTION
Progress on #128

## What It Does

Fixes an issue in which the table view header height was being miscalculated causing excessive vertical space on the `FeedbackViewController`. This is done by converting the header view to a table view cell.

Note that as a result of using self sizing cells, the checkmark cell is a bit taller now.

## How to Test

1. Run the app on iOS 10 built in the latest Xcode 8 beta.
1. Ensure there’s not excessive space between the screenshot and the label beneath it.

## Notes

- This is pointed to the `swift-3.0` branch, not `develop`.
- This will need to be duplicated on the `swift-2.3` branch once accepted.
- ~~This is based on the branch from #159, the most up-to-date revision that works in Beta 5. Please ensure that is merged before this to reduce the diff significantly.~~ I’ve merged in #161 so the reviewer need not have an older beta to test this. Please review / merge that first.