### PR TITLE
Makes `feedbackConfiguration` Non-Optional on `Feedback`

### DIFF
--- a/PinpointKit/PinpointKit/Sources/Feedback.swift
+++ b/PinpointKit/PinpointKit/Sources/Feedback.swift
@@ -63,7 +63,7 @@ public struct Feedback {
     let applicationInformation: ApplicationInformation?
     
     /// Specifies configurable properties for feedback.
-    public var configuration: FeedbackConfiguration?
+    public var configuration: FeedbackConfiguration
     
     /**
      Initializes a `Feedback` with optional default values.
@@ -76,7 +76,7 @@ public struct Feedback {
     init(screenshot: ScreenshotType,
         logs: [String]? = nil,
         applicationInformation: ApplicationInformation? = nil,
-        configuration: FeedbackConfiguration? = nil) {
+        configuration: FeedbackConfiguration) {
             self.screenshot = screenshot
             self.logs = logs
             self.applicationInformation = applicationInformation

--- a/PinpointKit/PinpointKit/Sources/FeedbackViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/FeedbackViewController.swift
@@ -167,6 +167,11 @@ public final class FeedbackViewController: UITableViewController {
     
     @objc private func sendButtonTapped() {
         
+        guard let feedbackConfiguration = feedbackConfiguration else {
+            assertionFailure("You must set `feedbackConfiguration` before attempting to send feedback.")
+            return
+        }
+        
         let logs = userEnabledLogCollection ? logCollector?.retrieveLogs() : nil
         
         let feedback: Feedback?

--- a/PinpointKit/PinpointKit/Sources/MailSender.swift
+++ b/PinpointKit/PinpointKit/Sources/MailSender.swift
@@ -96,23 +96,23 @@ public class MailSender: NSObject, Sender {
 private extension MFMailComposeViewController {
     
     func attachFeedback(feedback: Feedback) throws {
-        setToRecipients(feedback.configuration?.recipients)
+        setToRecipients(feedback.configuration.recipients)
         
-        if let subject = feedback.configuration?.title {
+        if let subject = feedback.configuration.title {
             setSubject(subject)
         }
         
-        if let body = feedback.configuration?.body {
+        if let body = feedback.configuration.body {
            setMessageBody(body, isHTML: false)
         }
         
-        try attachScreenshot(feedback.screenshot, screenshotFileName: feedback.configuration?.screenshotFileName ?? "Screenshot")
+        try attachScreenshot(feedback.screenshot, screenshotFileName: feedback.configuration.screenshotFileName)
         
         if let logs = feedback.logs {
-            try attachLogs(logs, logsFileName: feedback.configuration?.logsFileName ?? "logs")
+            try attachLogs(logs, logsFileName: feedback.configuration.logsFileName)
         }
         
-        if let additionalInformation = feedback.configuration?.additionalInformation {
+        if let additionalInformation = feedback.configuration.additionalInformation {
             attachAdditionalInformation(additionalInformation)
         }
     }


### PR DESCRIPTION
Closes #162

## What It Does

Makes `feedbackConfiguration` non-optional on `Feedback` to begin addressing [this comment](https://github.com/Lickability/PinpointKit/pull/161#discussion_r77398685).

## How to Test

Run the sample project on device and attempt to send feedback, ensuring that you don’t hit the new assertion failure.