### PR TITLE
Fixes Swift 3 Mail Compose Dismissal Bug

### DIFF
--- a/PinpointKit/PinpointKit/Sources/Core/MailSender.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/MailSender.swift
@@ -30,10 +30,10 @@ open class MailSender: NSObject, Sender {
         case mailCannotSend
         
         /// Email composing was canceled by the user.
-        case mailCanceled(underlyingError: NSError?)
+        case mailCanceled(underlyingError: Swift.Error?)
         
         /// Email sending failed.
-        case mailFailed(underlyingError: NSError?)
+        case mailFailed(underlyingError: Swift.Error?)
     }
     
     /// A success in sending feedback.
@@ -150,13 +150,13 @@ private extension MFMailComposeViewController {
 }
 
 extension MailSender: MFMailComposeViewControllerDelegate {
-    public func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: NSError?) {
+    public func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Swift.Error?) {
         controller.dismiss(animated: true) {
             self.completeWithResult(result, error: error)
         }
     }
     
-    private func completeWithResult(_ result: MFMailComposeResult, error: NSError?) {
+    private func completeWithResult(_ result: MFMailComposeResult, error: Swift.Error?) {
         switch result {
         case .cancelled:
             fail(with: .mailCanceled(underlyingError: error))


### PR DESCRIPTION
## What It Does

Fixes an issue in which the mail compose view controller would not properly dismiss. This is an issue with the Swift 3 migration. Since the signature for the `MFMailComposeViewControllerDelegate` method changed from including an `NSError` to an `Error`, the delegate method was no longer called. Other instances of this type of migration issue, such as in `UIApplicationDelegate` came with a warning, but this one did not.

Thanks to @salmankhann for pointing out this issue at #166. Since that PR has other changes that have been addressed in other PRs, this one isolates the mail compose dismissal issue only.

## How to Test

1. Launch the sample project on device using this branch in Xcode 8
1. Tap "Send"
1. Tap "Cancel", ensuring that the mail compose view controller dismisses
1. Tap "Send"
1. Actually send the message and ensure that the mail compose view controller dismisses
