### PR TITLE
Show Existing Screenshots in PinpointKit

### DIFF
--- a/Example/PinpointKitExample/ViewController.swift
+++ b/Example/PinpointKitExample/ViewController.swift
@@ -23,6 +23,6 @@ final class ViewController: UITableViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        pinpointKit.show(from: self, screenshot: #imageLiteral(resourceName: "liberatore"))
+        pinpointKit.show(from: self)
     }
 }

--- a/Example/PinpointKitExample/ViewController.swift
+++ b/Example/PinpointKitExample/ViewController.swift
@@ -23,6 +23,6 @@ final class ViewController: UITableViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        pinpointKit.show(from: self)
+        pinpointKit.show(from: self, screenshot: #imageLiteral(resourceName: "liberatore"))
     }
 }

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
@@ -56,9 +56,11 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         }()
     
     fileprivate let imageView: UIImageView = {
-        let view = UIImageView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        return view
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFit
+        
+        return imageView
     }()
     
     fileprivate let annotationsView: AnnotationsView = {

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
@@ -668,7 +668,7 @@ extension EditImageViewController: Editor {
         }
     }
     
-    private func clearAllAnnotations() {
+    public func clearAllAnnotations() {
         for annotationView in annotationsView.subviews where annotationView is AnnotationView {
             annotationView.removeFromSuperview()
         }

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/Editor.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/Editor.swift
@@ -21,6 +21,11 @@ public protocol Editor: class, InterfaceCustomizable {
      - parameter screenshot: The screenshot to be edited.
      */
     func setScreenshot(_ screenshot: UIImage)
+    
+    /**
+     Removes all annotations added to the editor.
+     */
+    func clearAllAnnotations()
 }
 
 extension Editor where Self: UIViewController {

--- a/PinpointKit/PinpointKit/Sources/Core/PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/PinpointKit.swift
@@ -53,7 +53,7 @@ open class PinpointKit {
      Shows PinpointKit’s feedback collection UI from a given view controller.
      
      - parameter viewController: The view controller from which to present.
-     - parameter screenshot:     The screenshot to be annotated. The default value is a screenshot taken at the time this method is called.
+     - parameter screenshot:     The screenshot to be annotated. The default value is a screenshot taken at the time this method is called. This image is intended to match the device’s screen size in points.
      */
     open func show(from viewController: UIViewController, screenshot: UIImage = Screenshotter.takeScreenshot()) {
         displayingViewController = viewController

--- a/PinpointKit/PinpointKit/Sources/Core/PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/PinpointKit.swift
@@ -57,7 +57,7 @@ open class PinpointKit {
      */
     open func show(from viewController: UIViewController, screenshot: UIImage = Screenshotter.takeScreenshot()) {
         displayingViewController = viewController
-        
+        configuration.editor.clearAllAnnotations()
         configuration.feedbackCollector.collectFeedback(with: screenshot, from: viewController)
     }
 }

--- a/PinpointKit/PinpointKit/Sources/Core/PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/PinpointKit.swift
@@ -53,9 +53,9 @@ open class PinpointKit {
      Shows PinpointKit’s feedback collection UI from a given view controller.
      
      - parameter viewController: The view controller from which to present.
+     - parameter screenshot:     The screenshot to be annotated. The default value is a screenshot taken at the time this method is called.
      */
-    open func show(from viewController: UIViewController) {
-        let screenshot = Screenshotter.takeScreenshot()
+    open func show(from viewController: UIViewController, screenshot: UIImage = Screenshotter.takeScreenshot()) {
         displayingViewController = viewController
         
         configuration.feedbackCollector.collectFeedback(with: screenshot, from: viewController)


### PR DESCRIPTION
Replaces #140, which is out-of-date with `develop` and in need of a few requested adjustments.

## What It Does

Allows passing other screenshots to PinpointKit than those taken at the time of presentation.

Note that the intended use is _still_ screenshots, not arbitrary images, but we set the image view’s aspect ratio to `.scaleAspectFit` to better support the edge case of an incorrectly-sized image.

## How to Test

1. `git revert -n 13af816`
1. Tap the image to edit it
1. Verify that the edits remain through multiple dismissals / presentations of the editor
1. Verify that the edits clear when canceling out of Pinpoint all together and then re-opening the editor (this was fixed in 271b08a).

## Notes

Closes #140 on merge.