### PR TITLE
Public Access Control for Feedback and MIMEType

### DIFF
--- a/Example/PinpointKitExample/ViewController.swift
+++ b/Example/PinpointKitExample/ViewController.swift
@@ -24,20 +24,5 @@ final class ViewController: UITableViewController {
         super.viewDidAppear(animated)
         
         pinpointKit.show(from: self)
-        
-        let screenshotType = Feedback.ScreenshotType.original(image: #imageLiteral(resourceName: "liberatore"))
-        let preferredImage = screenshotType.preferredImage
-        let applicationInformation: Feedback.ApplicationInformation = Feedback.ApplicationInformation(version: nil, build: nil, name: nil, bundleIdentifier: nil, operatingSystemVersion: nil)
-        
-        let feedbackConfiguration = FeedbackConfiguration(recipients: ["feedback@example.com"])
-        
-        let feedback = Feedback(screenshot: screenshotType, applicationInformation: applicationInformation, configuration: feedbackConfiguration)
-        
-        let mimeType = MIMEType.PlainText
-        print(mimeType.fileExtension)
-        
-        // Just to silence warnings of unused variables.
-        print(preferredImage)
-        print(feedback)
     }
 }

--- a/Example/PinpointKitExample/ViewController.swift
+++ b/Example/PinpointKitExample/ViewController.swift
@@ -24,5 +24,20 @@ final class ViewController: UITableViewController {
         super.viewDidAppear(animated)
         
         pinpointKit.show(from: self)
+        
+        let screenshotType = Feedback.ScreenshotType.original(image: #imageLiteral(resourceName: "liberatore"))
+        let preferredImage = screenshotType.preferredImage
+        let applicationInformation: Feedback.ApplicationInformation = Feedback.ApplicationInformation(version: nil, build: nil, name: nil, bundleIdentifier: nil, operatingSystemVersion: nil)
+        
+        let feedbackConfiguration = FeedbackConfiguration(recipients: ["feedback@example.com"])
+        
+        let feedback = Feedback(screenshot: screenshotType, applicationInformation: applicationInformation, configuration: feedbackConfiguration)
+        
+        let mimeType = MIMEType.PlainText
+        print(mimeType.fileExtension)
+        
+        // Just to silence warnings of unused variables.
+        print(preferredImage)
+        print(feedback)
     }
 }

--- a/PinpointKit/PinpointKit/Sources/Core/Feedback.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Feedback.swift
@@ -23,7 +23,7 @@ public struct Feedback {
         case combined(originalImage: UIImage, annotatedImage: UIImage)
         
         /// Returns an image of the screenshot preferring the annotated image.
-        var preferredImage: UIImage {
+        public var preferredImage: UIImage {
             switch self {
             case let .original(image):
                 return image
@@ -36,21 +36,38 @@ public struct Feedback {
     }
     
     /// A substructure containing information about the application and its environment.
-    struct ApplicationInformation {
+    public struct ApplicationInformation {
         /// The application’s marketing version.
-        let version: String?
+        public let version: String?
         
         /// The application’s build number.
-        let build: String?
+        public let build: String?
         
         /// The application’s display name.
-        let name: String?
+        public let name: String?
         
-        /// The application’s bundle identifer.
-        let bundleIdentifer: String?
+        /// The application’s bundle identifier.
+        public let bundleIdentifier: String?
         
         /// The operating system version of the OS in which the application is running.
-        let operatingSystemVersion: OperatingSystemVersion?
+        public let operatingSystemVersion: OperatingSystemVersion?
+        
+        /**
+         Initializes a new `ApplicationInformation`.
+         
+         - parameter version:                The application’s marketing version.
+         - parameter build:                  The application’s build number.
+         - parameter name:                   The application’s display name.
+         - parameter bundleIdentifier:       The application’s bundle identifier.
+         - parameter operatingSystemVersion: The operating system version of the OS in which the application is running.
+         */
+        public init(version: String?, build: String?, name: String?, bundleIdentifier: String?, operatingSystemVersion: OperatingSystemVersion?) {
+            self.version = version
+            self.build = build
+            self.name = name
+            self.bundleIdentifier = bundleIdentifier
+            self.operatingSystemVersion = operatingSystemVersion
+        }
     }
     
     /// A screenshot of the screen the feedback relates to.
@@ -60,7 +77,7 @@ public struct Feedback {
     public let logs: [String]?
     
     /// A struct containing information about the application and its environment.
-    let applicationInformation: ApplicationInformation?
+    public let applicationInformation: ApplicationInformation?
     
     /// Specifies configurable properties for feedback.
     public var configuration: FeedbackConfiguration
@@ -73,13 +90,13 @@ public struct Feedback {
      - parameter applicationInformation: Information about the application to be captured.
      - parameter configuration:          Configurable properties for feedback.
      */
-    init(screenshot: ScreenshotType,
-        logs: [String]? = nil,
-        applicationInformation: ApplicationInformation? = nil,
-        configuration: FeedbackConfiguration) {
-            self.screenshot = screenshot
-            self.logs = logs
-            self.applicationInformation = applicationInformation
-            self.configuration = configuration
+    public init(screenshot: ScreenshotType,
+                logs: [String]? = nil,
+                applicationInformation: ApplicationInformation? = nil,
+                configuration: FeedbackConfiguration) {
+        self.screenshot = screenshot
+        self.logs = logs
+        self.applicationInformation = applicationInformation
+        self.configuration = configuration
     }
 }

--- a/PinpointKit/PinpointKit/Sources/Core/MIMEType.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/MIMEType.swift
@@ -7,7 +7,7 @@
 //
 
 /// An enumeration of MIME types used in PinpointKit.
-enum MIMEType: String {
+public enum MIMEType: String {
     
     /// The MIME type used to represent a Portable Network Graphics image.
     case PNG = "image/png"
@@ -19,7 +19,7 @@ enum MIMEType: String {
     case JSON = "application/json"
     
     /// The file extension associated with the MIME type including the leading `.`.
-    var fileExtension: String {
+    public var fileExtension: String {
         switch self {
         case .PNG:
             return ".png"


### PR DESCRIPTION
Replaces #141, which is out-of-date with develop and in need of a few requested adjustments.

## What It Does

Makes available publicly all of `Feedback` and `MIMEType`, requiring a `public`/ defined member-wise initializer for `ApplicationInformation`.

## How to Test

- `git revert -n 1dee431`, build + run, to prove access to publicized information in the example app.
- Compare to #141 to ensure that I got everything being requested in that PR.

## Notes

Closes #141 on merge.