### PR TITLE
Adds More EditorDelegate Methods

### DIFF
--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
@@ -595,7 +595,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         guard let delegate = delegate else { return }
         guard let image = imageView.image else { assertionFailure(); return }
         
-        delegate.editorDidMakeChanges(self, to: image)
+        delegate.editorDidMakeChange(self, to: image)
     }
     
     // MARK: - UIGestureRecognizerDelegate

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
@@ -404,10 +404,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         let isEditingTextView = currentTextAnnotationView?.textView.isFirstResponder ?? false
         currentAnnotationView = isEditingTextView ? currentAnnotationView : nil
         
-        if let delegate = delegate {
-            guard let image = imageView.image else { assertionFailure(); return }
-            delegate.editorDidMakeChanges(self, to: image)
-        }
+        informDelegateOfChange()
     }
     
     @objc private func toolChanged(_ segmentedControl: UISegmentedControl) {
@@ -574,6 +571,8 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         let removeAnnotationView = {
             self.endEditingTextView()
             annotationView.removeFromSuperview()
+            
+            self.informDelegateOfChange()
         }
         
         if animated {
@@ -590,6 +589,13 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         if let selectedAnnotationView = selectedAnnotationView {
             deleteAnnotationView(selectedAnnotationView, animated: true)
         }
+    }
+    
+    private func informDelegateOfChange() {
+        guard let delegate = delegate else { return }
+        guard let image = imageView.image else { assertionFailure(); return }
+        
+        delegate.editorDidMakeChanges(self, to: image)
     }
     
     // MARK: - UIGestureRecognizerDelegate

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditorDelegate.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditorDelegate.swift
@@ -41,7 +41,7 @@ public protocol EditorDelegate: class {
      - parameter editor: The editor resonsible for editing the image.
      - parameter screenshot: The edited image of a screenshot.
      */
-    func editorDidMakeChanges(_ editor: Editor, to screenshot: UIImage)
+    func editorDidMakeChange(_ editor: Editor, to screenshot: UIImage)
 }
 
 /// Extends editor delegate with base implementation for functions.
@@ -55,7 +55,7 @@ extension EditorDelegate {
         return true
     }
     
-    public func editorDidMakeChanges(_ editor: Editor, to screenshot: UIImage) {
+    public func editorDidMakeChange(_ editor: Editor, to screenshot: UIImage) {
         // Do nothing
     }
 }

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditorDelegate.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditorDelegate.swift
@@ -10,6 +10,24 @@
 public protocol EditorDelegate: class {
     
     /**
+     A method that is called any time the editor makes a modification to the screenshot.
+     
+     - parameter editor: The editor resonsible for editing the image.
+     - parameter screenshot: The edited image of a screenshot.
+     */
+    func editorDidMakeChange(_ editor: Editor, to screenshot: UIImage)
+    
+    /**
+     A method that is called with an image to ask if the editor should be dismissed.
+     
+     - parameter editor: The editor resonsible for editing the image.
+     - parameter screenshot: The edited image of a screenshot, after editing is complete.
+     
+     - returns: A bool value that defines if the editor dismisses or not.
+     */
+    func editorShouldDismiss(_ editor: Editor, with screenshot: UIImage) -> Bool
+    
+    /**
      A method that is called with an image just before the editor is dismissed.
      
      - parameter editor: The editor resonsible for editing the image.
@@ -24,30 +42,12 @@ public protocol EditorDelegate: class {
      - parameter screenshot: The edited image of a screenshot, after editing is complete.
      */
     func editorDidDismiss(_ editor: Editor, with screenshot: UIImage)
-    
-    /**
-     A method that is called with an image to ask if the editor should be dismissed.
- 
-    - parameter editor: The editor resonsible for editing the image.
-    - parameter screenshot: The edited image of a screenshot, after editing is complete.
-    
-    - returns: A bool value that defines if the editor dismisses or not.
-     */
-    func editorShouldDismiss(_ editor: Editor, with screenshot: UIImage) -> Bool
-    
-    /**
-     A method that is called any time the editor makes a modification to the screenshot.
-     
-     - parameter editor: The editor resonsible for editing the image.
-     - parameter screenshot: The edited image of a screenshot.
-     */
-    func editorDidMakeChange(_ editor: Editor, to screenshot: UIImage)
 }
 
 /// Extends editor delegate with base implementation for functions.
 extension EditorDelegate {
     
-    public func editorDidDismiss(_ editor: Editor, with screenshot: UIImage) {
+    public func editorDidMakeChange(_ editor: Editor, to screenshot: UIImage) {
         // Do nothing
     }
     
@@ -55,7 +55,7 @@ extension EditorDelegate {
         return true
     }
     
-    public func editorDidMakeChange(_ editor: Editor, to screenshot: UIImage) {
+    public func editorDidDismiss(_ editor: Editor, with screenshot: UIImage) {
         // Do nothing
     }
 }

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditorDelegate.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditorDelegate.swift
@@ -10,7 +10,7 @@
 public protocol EditorDelegate: class {
     
     /**
-     A function that is called with an image just before the editor is dismissed.
+     A method that is called with an image just before the editor is dismissed.
      
      - parameter editor: The editor resonsible for editing the image.
      - parameter screenshot: The edited image of a screenshot, after editing is complete.
@@ -18,7 +18,7 @@ public protocol EditorDelegate: class {
     func editorWillDismiss(_ editor: Editor, with screenshot: UIImage)
     
     /**
-     A function that is called with an image just after the editor was dismissed.
+     A method that is called with an image just after the editor was dismissed.
      
      - parameter editor: The editor resonsible for editing the image.
      - parameter screenshot: The edited image of a screenshot, after editing is complete.
@@ -26,7 +26,7 @@ public protocol EditorDelegate: class {
     func editorDidDismiss(_ editor: Editor, with screenshot: UIImage)
     
     /**
-     A function that is called with an image to ask if the editor should be dismissed.
+     A method that is called with an image to ask if the editor should be dismissed.
  
     - parameter editor: The editor resonsible for editing the image.
     - parameter screenshot: The edited image of a screenshot, after editing is complete.
@@ -36,7 +36,7 @@ public protocol EditorDelegate: class {
     func editorShouldDismiss(_ editor: Editor, with screenshot: UIImage) -> Bool
     
     /**
-     A function that is called any time the editor makes a modification to the screenshot.
+     A method that is called any time the editor makes a modification to the screenshot.
      
      - parameter editor: The editor resonsible for editing the image.
      - parameter screenshot: The edited image of a screenshot.

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditorDelegate.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditorDelegate.swift
@@ -18,6 +18,14 @@ public protocol EditorDelegate: class {
     func editorWillDismiss(_ editor: Editor, with screenshot: UIImage)
     
     /**
+     A function that is called with an image just after the editor was dismissed.
+     
+     - parameter editor: The editor resonsible for editing the image.
+     - parameter screenshot: The edited image of a screenshot, after editing is complete.
+     */
+    func editorDidDismiss(_ editor: Editor, with screenshot: UIImage)
+    
+    /**
      A function that is called with an image to ask if the editor should be dismissed.
  
     - parameter editor: The editor resonsible for editing the image.
@@ -26,11 +34,28 @@ public protocol EditorDelegate: class {
     - returns: A bool value that defines if the editor dismisses or not.
      */
     func editorShouldDismiss(_ editor: Editor, with screenshot: UIImage) -> Bool
+    
+    /**
+     A function that is called any time the editor makes a modification to the screenshot.
+     
+     - parameter editor: The editor resonsible for editing the image.
+     - parameter screenshot: The edited image of a screenshot.
+     */
+    func editorDidMakeChanges(_ editor: Editor, to screenshot: UIImage)
 }
 
 /// Extends editor delegate with base implementation for functions.
 extension EditorDelegate {
+    
+    public func editorDidDismiss(_ editor: Editor, with screenshot: UIImage) {
+        // Do nothing
+    }
+    
     public func editorShouldDismiss(_ editor: Editor, with screenshot: UIImage) -> Bool {
         return true
+    }
+    
+    public func editorDidMakeChanges(_ editor: Editor, to screenshot: UIImage) {
+        // Do nothing
     }
 }


### PR DESCRIPTION
📝 Based on #182. Please merge that first.

This PR provides clients additional hooks into the `Editor`.

To test, set breakpoints in the default implementations of the new function and ensure they get called when:

- Making any changes to annotations (adding, removing, resizing, deleting via double tap, deleting via menu item) (`editorDidMakeChanges`)
- Dismissing the edit image view controller (`editorDidDismiss`)