### PR TITLE
Adjustments to Editor Protocol

### DIFF
--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
@@ -632,14 +632,24 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
 }
 
 extension EditImageViewController: Editor {
-    public func setScreenshot(_ screenshot: UIImage) {
-        let oldScreenshot = imageView.image
-        
-        imageView.image = screenshot
-        
-        if screenshot != oldScreenshot {
-            clearAllAnnotations()
+
+    public var screenshot: UIImage? {
+        get {
+            return imageView.image
         }
+        set {
+            let oldScreenshot = imageView.image
+            
+            imageView.image = newValue
+            
+            if newValue != oldScreenshot {
+                clearAllAnnotations()
+            }
+        }
+    }
+    
+    public var numberOfAnnotations: Int {
+        return annotationsView.subviews.count
     }
     
     public func clearAllAnnotations() {

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
@@ -633,6 +633,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
 
 extension EditImageViewController: Editor {
 
+    /// The screenshot, without annotations. Note that setting a new image will clear all annotations in the editor. 
     public var screenshot: UIImage? {
         get {
             return imageView.image

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/Editor.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/Editor.swift
@@ -15,12 +15,11 @@ public protocol Editor: class, InterfaceCustomizable {
     /// The view controller that displays the image being edited.
     var viewController: UIViewController { get }
     
-    /**
-     Sets the screenshot to be edited.
-     
-     - parameter screenshot: The screenshot to be edited.
-     */
-    func setScreenshot(_ screenshot: UIImage)
+    /// The number of annotations added to the editor.
+    var numberOfAnnotations: Int { get }
+    
+    /// The screenshot, without annotations.
+    var screenshot: UIImage? { get set }
     
     /**
      Removes all annotations added to the editor.

--- a/PinpointKit/PinpointKit/Sources/Core/FeedbackViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/FeedbackViewController.swift
@@ -232,7 +232,7 @@ extension FeedbackViewController: FeedbackTableViewDataSourceDelegate {
         guard let editor = editor else { return }
         guard let screenshotToEdit = self.screenshot else { return }
         
-        editor.setScreenshot(screenshotToEdit)
+        editor.screenshot = screenshotToEdit
         
         let editImageViewController = NavigationController(rootViewController: editor.viewController)
         editImageViewController.view.tintColor = interfaceCustomization?.appearance.tintColor


### PR DESCRIPTION
:memo: Based on #182 and #183, please merge those first.

- Makes `screenshot` a `{ get set }` on `Editor` instead of just being able to set it, so that it can be retrieved later if needed.
- Adds `numberOfAnnotations` to `Editor` so that clients can know the number of annotations, to e.g. warn the user of dismissal if they’ve made a certain number of annotations.

To test, you can add a print statement to the default implementation of `editorDidMakeChanges(_:to:)` as follows:

```swift
public func editorDidMakeChanges(_ editor: Editor, to screenshot: UIImage) {
    print(editor.numberOfAnnotations)
}
```

Then when you make any edits, ensure the value printed to the console matches the number of annotations on screen.