### PR TITLE
Bar Button Item Customization

### DIFF
--- a/Example/PinpointKitExample/ViewController.swift
+++ b/Example/PinpointKitExample/ViewController.swift
@@ -11,7 +11,19 @@ import PinpointKit
 
 final class ViewController: UITableViewController {
     
-    fileprivate let pinpointKit = PinpointKit(feedbackRecipients: ["feedback@example.com"])
+    fileprivate let pinpointKit = PinpointKit(configuration: Configuration(editor: {
+        
+        // Create a custom editor
+        let editImageViewController = EditImageViewController()
+        
+        
+        // Associate that custom bar button item provider with the ditor.
+        editImageViewController.barButtonItemProvider = MyButtonProvider(editImageViewController: editImageViewController)
+        
+        return editImageViewController
+        
+        }(), feedbackConfiguration: FeedbackConfiguration(recipients: ["example@something.com"]))
+    )
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -24,5 +36,29 @@ final class ViewController: UITableViewController {
         super.viewDidAppear(animated)
         
         pinpointKit.show(from: self)
+    }
+}
+
+// Create a custom bar button item provider class
+class MyButtonProvider: EditImageViewControllerBarButtonItemProviding {
+    private weak var editImageViewController: EditImageViewController?
+    
+    init(editImageViewController: EditImageViewController) {
+        self.editImageViewController = editImageViewController
+    }
+    
+    lazy var leftBarButtonItem: UIBarButtonItem? = UIBarButtonItem(title: "CLOSE!", style: .done, target: self, action: #selector(MyButtonProvider.close(sender:)))
+    
+    
+    lazy var rightBarButtonItem: UIBarButtonItem? = UIBarButtonItem(title: "LOG!", style: .plain, target: self, action: #selector(MyButtonProvider.logSomething(sender:)))
+    
+    let allowsHidingBarButtonItemsWhileEditingTextAnnotations: Bool = true
+    
+    @objc private func close(sender: UIBarButtonItem) {
+        self.editImageViewController?.attemptToDismiss(animated: true)
+    }
+    
+    @objc private func logSomething(sender: UIBarButtonItem) {
+        print("HEY")
     }
 }

--- a/Example/PinpointKitExample/ViewController.swift
+++ b/Example/PinpointKitExample/ViewController.swift
@@ -11,19 +11,7 @@ import PinpointKit
 
 final class ViewController: UITableViewController {
     
-    fileprivate let pinpointKit = PinpointKit(configuration: Configuration(editor: {
-        
-        // Create a custom editor
-        let editImageViewController = EditImageViewController()
-        
-        
-        // Associate that custom bar button item provider with the ditor.
-        editImageViewController.barButtonItemProvider = MyButtonProvider(editImageViewController: editImageViewController)
-        
-        return editImageViewController
-        
-        }(), feedbackConfiguration: FeedbackConfiguration(recipients: ["example@something.com"]))
-    )
+    fileprivate let pinpointKit = PinpointKit(feedbackRecipients: ["feedback@example.com"])
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -36,29 +24,5 @@ final class ViewController: UITableViewController {
         super.viewDidAppear(animated)
         
         pinpointKit.show(from: self)
-    }
-}
-
-// Create a custom bar button item provider class
-class MyButtonProvider: EditImageViewControllerBarButtonItemProviding {
-    private weak var editImageViewController: EditImageViewController?
-    
-    init(editImageViewController: EditImageViewController) {
-        self.editImageViewController = editImageViewController
-    }
-    
-    lazy var leftBarButtonItem: UIBarButtonItem? = UIBarButtonItem(title: "CLOSE!", style: .done, target: self, action: #selector(MyButtonProvider.close(sender:)))
-    
-    
-    lazy var rightBarButtonItem: UIBarButtonItem? = UIBarButtonItem(title: "LOG!", style: .plain, target: self, action: #selector(MyButtonProvider.logSomething(sender:)))
-    
-    let allowsHidingBarButtonItemsWhileEditingTextAnnotations: Bool = true
-    
-    @objc private func close(sender: UIBarButtonItem) {
-        self.editImageViewController?.attemptToDismiss(animated: true)
-    }
-    
-    @objc private func logSomething(sender: UIBarButtonItem) {
-        print("HEY")
     }
 }

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		40A2B3349ED694133C5072C4DBC22CFA /* ASLLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = CBE6EBE3EE7E185D19A3DD6CD0BAA6F9 /* ASLLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		46AEAECF7531C2384192AAA51FDE6930 /* UIColor+Palette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE276403499131D008CB6BA709475D0 /* UIColor+Palette.swift */; };
 		48F822008D266B4351F8FF4CDBF93442 /* Editor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C238D1A284842EB711EB29E9B69F299 /* Editor.swift */; };
+		4CB771201DCD316C001FC154 /* EditImageViewControllerBarButtonItemProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB7711F1DCD316C001FC154 /* EditImageViewControllerBarButtonItemProviding.swift */; };
 		4F23890ECB2FCD34611153312EB69303 /* TextAnnotationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBBC5604F3145AF00D9544D70E3B9C53 /* TextAnnotationView.swift */; };
 		518C1C0194CD3DE3DEDF951FE46BEED4 /* FeedbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7309EA9BDF3948F545BC8DF65395B68D /* FeedbackViewController.swift */; };
 		578A5E810F8762F2A2505A7BC1F52370 /* Screen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F61D6816EA76CDC4EDF0F1337891CC /* Screen.swift */; };
@@ -109,6 +110,7 @@
 		442353394785B418C9A5C78E02204798 /* EditImageViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EditImageViewController.swift; sourceTree = "<group>"; };
 		46EB4256B443AF96A12DA037BBA014A4 /* Configuration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		490CCE9AF334D7DE35D176D874C0B3C4 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4CB7711F1DCD316C001FC154 /* EditImageViewControllerBarButtonItemProviding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditImageViewControllerBarButtonItemProviding.swift; sourceTree = "<group>"; };
 		521052D2CB6D84A7FEBDBFFCE2A73EEF /* Screenshotter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Screenshotter.swift; sourceTree = "<group>"; };
 		5C238D1A284842EB711EB29E9B69F299 /* Editor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Editor.swift; sourceTree = "<group>"; };
 		5E130DAE16C32980DA74035C2A7F56DA /* ShakeDetectingWindowDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ShakeDetectingWindowDelegate.swift; sourceTree = "<group>"; };
@@ -240,6 +242,7 @@
 			children = (
 				34946ECD573272B07976767F4BD6E58B /* AnnotationViewFactory.swift */,
 				442353394785B418C9A5C78E02204798 /* EditImageViewController.swift */,
+				4CB7711F1DCD316C001FC154 /* EditImageViewControllerBarButtonItemProviding.swift */,
 				5C238D1A284842EB711EB29E9B69F299 /* Editor.swift */,
 				1E4719CE9D422494280E1434908D4CC0 /* EditorDelegate.swift */,
 				0BE2A7251C04383DC54945C6085E87F0 /* Tool.swift */,
@@ -574,6 +577,7 @@
 				A6F5B257EA88D86A136A357617839D9D /* PinpointKit.swift in Sources */,
 				578A5E810F8762F2A2505A7BC1F52370 /* Screen.swift in Sources */,
 				F7488AB5559C5A0E64A3819B5B831D42 /* ScreenshotCell.swift in Sources */,
+				4CB771201DCD316C001FC154 /* EditImageViewControllerBarButtonItemProviding.swift in Sources */,
 				5AEBDF41B7855864EB12FACA4FFCB160 /* Screenshotter.swift in Sources */,
 				EAF80411FD205A30714824F17DABF24D /* Sender.swift in Sources */,
 				C891F3B20C8E59859853EAC529251DBC /* ShakeDetectingWindow.swift in Sources */,

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
@@ -185,8 +185,8 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         
         assert(imageView.image != nil, "A screenshot must be set using `setScreenshot(_:)` before loading the view.")
         
-        navigationItem.rightBarButtonItem = barButtonItemProvider?.rightBarButtonItem
         navigationItem.leftBarButtonItem = barButtonItemProvider?.leftBarButtonItem
+        navigationItem.rightBarButtonItem = barButtonItemProvider?.rightBarButtonItem
         
         view.backgroundColor = .white
         view.addSubview(imageView)
@@ -421,8 +421,8 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
                 currentTextAnnotationView?.removeFromSuperview()
             }
             
-            navigationItem.setRightBarButton(barButtonItemProvider?.rightBarButtonItem, animated: true)
             navigationItem.setLeftBarButton(barButtonItemProvider?.leftBarButtonItem, animated: true)
+            navigationItem.setRightBarButton(barButtonItemProvider?.rightBarButtonItem, animated: true)
             
             currentAnnotationView = nil
         }

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
@@ -395,7 +395,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         guard let currentTextAnnotationView = currentTextAnnotationView else { return }
         currentTextAnnotationView.beginEditing()
         
-        guard barButtonItemProvider?.allowsHidingBarButtonItemsWhileEditingTextAnnotations == true else { return }
+        guard barButtonItemProvider?.hidesBarButtonItemsWhileEditingTextAnnotations == true else { return }
         
         guard let buttonFont = interfaceCustomization?.appearance.editorTextAnnotationDismissButtonFont else { assertionFailure(); return }
         let dismissButton = UIBarButtonItem(title: interfaceCustomization?.interfaceText.textEditingDismissButtonTitle, style: .done, target: self, action: #selector(EditImageViewController.endEditingTextViewIfFirstResponder))
@@ -692,7 +692,7 @@ extension EditImageViewController: Editor {
 private class DefaultBarButtonItemProvider: EditImageViewControllerBarButtonItemProviding {
     public let leftBarButtonItem: UIBarButtonItem? = nil
     public let rightBarButtonItem: UIBarButtonItem?
-    public let allowsHidingBarButtonItemsWhileEditingTextAnnotations = true
+    public let hidesBarButtonItemsWhileEditingTextAnnotations = true
     
     public init(interfaceCustomization: InterfaceCustomization, rightBarButtonItemTarget: AnyObject?, rightBarButtonItemSelector: Selector) {
         rightBarButtonItem = UIBarButtonItem(doneButtonWithTarget: rightBarButtonItemTarget, title: interfaceCustomization.interfaceText.editorDoneButtonTitle, font: interfaceCustomization.appearance.editorDoneButtonFont, action: rightBarButtonItemSelector)

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
@@ -318,20 +318,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
     }
     
     @objc private func doneButtonTapped(_ button: UIBarButtonItem) {
-        guard let delegate = delegate else {
-            dismiss(animated: true, completion: nil)
-            return
-        }
-        
-        let screenshot = self.view.pinpoint_screenshot
-        if delegate.editorShouldDismiss(self, with: screenshot) {
-            delegate.editorWillDismiss(self, with: screenshot)
-            
-            dismiss(animated: true) { [weak self] in
-                guard let strongSelf = self else { return }
-                delegate.editorDidDismiss(strongSelf, with: screenshot)
-            }
-        }
+        attemptToDismiss(animated: true)
     }
     
     @objc private func handleTouchDownGestureRecognizer(_ gestureRecognizer: UILongPressGestureRecognizer) {

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
@@ -703,13 +703,9 @@ extension EditImageViewController: Editor {
 }
 
 private class DefaultBarButtonItemProvider: EditImageViewControllerBarButtonItemProviding {
-    
     public let leftBarButtonItem: UIBarButtonItem? = nil
     public let rightBarButtonItem: UIBarButtonItem?
-    
-    public var allowsHidingBarButtonItemsWhileEditingTextAnnotations: Bool {
-        return true
-    }
+    public let allowsHidingBarButtonItemsWhileEditingTextAnnotations = true
     
     public init(interfaceCustomization: InterfaceCustomization, rightBarButtonItemTarget: AnyObject?, rightBarButtonItemSelector: Selector) {
         rightBarButtonItem = UIBarButtonItem(doneButtonWithTarget: rightBarButtonItemTarget, title: interfaceCustomization.interfaceText.editorDoneButtonTitle, font: interfaceCustomization.appearance.editorDoneButtonFont, action: rightBarButtonItemSelector)

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
@@ -397,7 +397,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         
         guard barButtonItemProvider?.allowsHidingBarButtonItemsWhileEditingTextAnnotations == true else { return }
         
-        guard let buttonFont = interfaceCustomization?.appearance.editorTextAnnotationDoneButtonFont else { assertionFailure(); return }
+        guard let buttonFont = interfaceCustomization?.appearance.editorTextAnnotationDismissButtonFont else { assertionFailure(); return }
         let dismissButton = UIBarButtonItem(title: interfaceCustomization?.interfaceText.textEditingDismissButtonTitle, style: .done, target: self, action: #selector(EditImageViewController.endEditingTextViewIfFirstResponder))
         dismissButton.setTitleTextAttributes([NSFontAttributeName: buttonFont], for: UIControlState())
         

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
@@ -281,7 +281,9 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
     // MARK: - EditImageViewController
     
     /**
-     Dismisses the receiver if `delegate` is `nil` or returns `true` for `editorShouldDismiss(_:with:)`. If `delegate` returns `true`, `editorWillDismiss(_:with:)` and `editorDidDismiss(_:with:)` will be called.
+     Dismisses the receiver if `delegate` is `nil` or returns `true` for `editorShouldDismiss(_:with:)`. If `delegate` returns `true`, `editorWillDismiss(_:with:)` and `editorDidDismiss(_:with:)` will be called before and after, respectively.
+     
+     - parameter animated: Whether dismissal is animated.
      */
     public func attemptToDismiss(animated: Bool) {
         guard let delegate = delegate else {

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewControllerBarButtonItemProviding.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewControllerBarButtonItemProviding.swift
@@ -1,0 +1,22 @@
+//
+//  EditImageViewControllerBarButtonItemProviding.swift
+//  Pods
+//
+//  Created by Michael Liberatore on 11/4/16.
+//
+//
+
+import UIKit
+
+/// Describes a type that specifies the bar button items of an `EditImageViewController` and their behaviors.
+public protocol EditImageViewControllerBarButtonItemProviding {
+    
+    /// The left bar button item.
+    var leftBarButtonItem: UIBarButtonItem? { get }
+    
+    /// The right bar button item.
+    var rightBarButtonItem: UIBarButtonItem? { get }
+    
+    /// Whether the `EditImageViewController` can hide the bar button items while editing a text annotation and display its own dismiss button for ending the editing of text.
+    var allowsHidingBarButtonItemsWhileEditingTextAnnotations: Bool { get }
+}

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewControllerBarButtonItemProviding.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewControllerBarButtonItemProviding.swift
@@ -17,6 +17,6 @@ public protocol EditImageViewControllerBarButtonItemProviding {
     /// The right bar button item.
     var rightBarButtonItem: UIBarButtonItem? { get }
     
-    /// Whether the `EditImageViewController` can hide the bar button items while editing a text annotation and display its own dismiss button for ending the editing of text.
-    var allowsHidingBarButtonItemsWhileEditingTextAnnotations: Bool { get }
+    /// Whether the `EditImageViewController` hides the bar button items while editing a text annotation to display its own dismiss button for ending the editing of text.
+    var hidesBarButtonItemsWhileEditingTextAnnotations: Bool { get }
 }

--- a/PinpointKit/PinpointKit/Sources/Core/InterfaceCustomization.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/InterfaceCustomization.swift
@@ -84,7 +84,7 @@ public struct InterfaceCustomization {
          - parameter logCollectionPermissionFont:           The font used for the title of the cell that allows the user to toggle log collection.
          - parameter logFont:                               The font used for displaying logs.
          - parameter editorTextAnnotationSegmentFont:       The font used for the text annotation tool segment in the editor.
-         - parameter editorTextAnnotationDismissButtonFont: The font used for the done button in the editor displayed while editing a text annotation.
+         - parameter editorTextAnnotationDismissButtonFont: The font used for the dismiss button in the editor displayed while editing a text annotation.
          - parameter editorDoneButtonFont:                  The font used for the done button in the editor to finish editing the image.
          */
         public init(tintColor: UIColor? = .pinpointOrange(),

--- a/PinpointKit/PinpointKit/Sources/Core/InterfaceCustomization.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/InterfaceCustomization.swift
@@ -66,6 +66,9 @@ public struct InterfaceCustomization {
         /// The font used for the done button in the editor displayed while editing a text annotation.
         let editorTextAnnotationDoneButtonFont: UIFont
         
+        /// The font used for the done button in the editor to finish editing the image.
+        let editorDoneButtonFont: UIFont
+        
         /**
          Initializes an `Appearance` object with a optional annotation color properties.
          
@@ -82,6 +85,7 @@ public struct InterfaceCustomization {
          - parameter logFont:                            The font used for displaying logs.
          - parameter editorTextAnnotationSegmentFont:    The font used for the text annotation tool segment in the editor.
          - parameter editorTextAnnotationDoneButtonFont: The font used for the done button in the editor displayed while editing a text annotation.
+         - parameter editorDoneButtonFont:               The font used for the done button in the editor to finish editing the image.
          */
         public init(tintColor: UIColor? = .pinpointOrange(),
                     annotationFillColor: UIColor? = nil,
@@ -95,7 +99,8 @@ public struct InterfaceCustomization {
                     logCollectionPermissionFont: UIFont = .sourceSansProFont(ofSize: 19),
                     logFont: UIFont = .menloRegularFont(ofSize: 10),
                     editorTextAnnotationSegmentFont: UIFont = .sourceSansProFont(ofSize: 18),
-                    editorTextAnnotationDoneButtonFont: UIFont = .sourceSansProFont(ofSize: 19, weight: .semibold)) {
+                    editorTextAnnotationDoneButtonFont: UIFont = .sourceSansProFont(ofSize: 19, weight: .semibold),
+                    editorDoneButtonFont: UIFont = .sourceSansProFont(ofSize: 19, weight: .semibold)) {
             self.tintColor = tintColor
             self.annotationFillColor = annotationFillColor
             self.annotationStrokeColor = annotationStrokeColor
@@ -120,6 +125,7 @@ public struct InterfaceCustomization {
             self.logCollectionPermissionFont = logCollectionPermissionFont
             self.editorTextAnnotationSegmentFont = editorTextAnnotationSegmentFont
             self.editorTextAnnotationDoneButtonFont = editorTextAnnotationDoneButtonFont
+            self.editorDoneButtonFont = editorDoneButtonFont
         }
     }
     
@@ -152,8 +158,8 @@ public struct InterfaceCustomization {
         ///  The title of a button that cancels text editing.
         let textEditingDismissButtonTitle: String
         
-        ///  The title of a button that cancels text editing.
-        let textEditingDoneButtonTitle: String
+        ///  The title of a button that ends editing of the image.
+        let editorDoneButtonTitle: String
         
         /**
          Initializes an `InterfaceText` with custom values, using a default if a particular property is unspecified.
@@ -166,7 +172,7 @@ public struct InterfaceCustomization {
          - parameter logCollectorTitle:             The title of the log collector.
          - parameter logCollectionPermissionTitle:  The title of the permission button.
          - parameter textEditingDismissButtonTitle: The title of the text editing dismiss button.
-         - parameter textEditingDoneButtonTitle:    The title of the text editing done button.
+         - parameter editorDoneButtonTitle:         The title of a button that ends editing of the image.
          */
         public init(feedbackCollectorTitle: String? = NSLocalizedString("Report a Bug", comment: "Title of a view that reports a bug"),
                     feedbackSendButtonTitle: String = NSLocalizedString("Send", comment: "A button that sends feedback."),
@@ -176,7 +182,7 @@ public struct InterfaceCustomization {
                     logCollectorTitle: String? = NSLocalizedString("Console Log", comment: "Title of a view that collects logs"),
                     logCollectionPermissionTitle: String = NSLocalizedString("Include Console Log", comment: "Title of a button asking the user to include system logs"),
                     textEditingDismissButtonTitle: String = NSLocalizedString("Dismiss", comment: "Title of a button that dismisses text editing"),
-                    textEditingDoneButtonTitle: String = NSLocalizedString("Done", comment: "Title of a button that finish editing")) {
+                    editorDoneButtonTitle: String = NSLocalizedString("Done", comment: "Title of a button that finishes editing")) {
             self.feedbackCollectorTitle = feedbackCollectorTitle
             self.feedbackSendButtonTitle = feedbackSendButtonTitle
             self.feedbackCancelButtonTitle = feedbackCancelButtonTitle
@@ -185,7 +191,7 @@ public struct InterfaceCustomization {
             self.logCollectorTitle = logCollectorTitle
             self.logCollectionPermissionTitle = logCollectionPermissionTitle
             self.textEditingDismissButtonTitle = textEditingDismissButtonTitle
-            self.textEditingDoneButtonTitle = textEditingDoneButtonTitle
+            self.editorDoneButtonTitle = editorDoneButtonTitle
         }
     }
 }

--- a/PinpointKit/PinpointKit/Sources/Core/InterfaceCustomization.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/InterfaceCustomization.swift
@@ -63,8 +63,8 @@ public struct InterfaceCustomization {
         /// The font used for the text annotation tool segment in the editor.
         let editorTextAnnotationSegmentFont: UIFont
         
-        /// The font used for the done button in the editor displayed while editing a text annotation.
-        let editorTextAnnotationDoneButtonFont: UIFont
+        /// The font used for the dismiss button in the editor displayed while editing a text annotation.
+        let editorTextAnnotationDismissButtonFont: UIFont
         
         /// The font used for the done button in the editor to finish editing the image.
         let editorDoneButtonFont: UIFont
@@ -72,20 +72,20 @@ public struct InterfaceCustomization {
         /**
          Initializes an `Appearance` object with a optional annotation color properties.
          
-         - parameter tintColor:                          The tint color of the interface.
-         - parameter annotationFillColor:                The fill color for annotations. If none is supplied, the `tintColor` of the relevant view will be used.
-         - parameter annotationStrokeColor:              The stroke color for annotations.
-         - parameter annotationTextAttributes:           The text attributes for annotations.
-         - parameter navigationTitleFont:                The font used for navigation titles.
-         - parameter feedbackSendButtonFont:             The font used for the button that sends feedback.
-         - parameter feedbackCancelButtonFont:           The font used for the button that cancels feedback collection.
-         - parameter feedbackEditHintFont:               The font used for the hint to the user on how to edit the screenshot from the feedback screen.
-         - parameter feedbackBackButtonFont:             The font used for the back button that takes the user back to the initial feedback collection screen.
-         - parameter logCollectionPermissionFont:        The font used for the title of the cell that allows the user to toggle log collection.
-         - parameter logFont:                            The font used for displaying logs.
-         - parameter editorTextAnnotationSegmentFont:    The font used for the text annotation tool segment in the editor.
-         - parameter editorTextAnnotationDoneButtonFont: The font used for the done button in the editor displayed while editing a text annotation.
-         - parameter editorDoneButtonFont:               The font used for the done button in the editor to finish editing the image.
+         - parameter tintColor:                             The tint color of the interface.
+         - parameter annotationFillColor:                   The fill color for annotations. If none is supplied, the `tintColor` of the relevant view will be used.
+         - parameter annotationStrokeColor:                 The stroke color for annotations.
+         - parameter annotationTextAttributes:              The text attributes for annotations.
+         - parameter navigationTitleFont:                   The font used for navigation titles.
+         - parameter feedbackSendButtonFont:                The font used for the button that sends feedback.
+         - parameter feedbackCancelButtonFont:              The font used for the button that cancels feedback collection.
+         - parameter feedbackEditHintFont:                  The font used for the hint to the user on how to edit the screenshot from the feedback screen.
+         - parameter feedbackBackButtonFont:                The font used for the back button that takes the user back to the initial feedback collection screen.
+         - parameter logCollectionPermissionFont:           The font used for the title of the cell that allows the user to toggle log collection.
+         - parameter logFont:                               The font used for displaying logs.
+         - parameter editorTextAnnotationSegmentFont:       The font used for the text annotation tool segment in the editor.
+         - parameter editorTextAnnotationDismissButtonFont: The font used for the done button in the editor displayed while editing a text annotation.
+         - parameter editorDoneButtonFont:                  The font used for the done button in the editor to finish editing the image.
          */
         public init(tintColor: UIColor? = .pinpointOrange(),
                     annotationFillColor: UIColor? = nil,
@@ -99,7 +99,7 @@ public struct InterfaceCustomization {
                     logCollectionPermissionFont: UIFont = .sourceSansProFont(ofSize: 19),
                     logFont: UIFont = .menloRegularFont(ofSize: 10),
                     editorTextAnnotationSegmentFont: UIFont = .sourceSansProFont(ofSize: 18),
-                    editorTextAnnotationDoneButtonFont: UIFont = .sourceSansProFont(ofSize: 19, weight: .semibold),
+                    editorTextAnnotationDismissButtonFont: UIFont = .sourceSansProFont(ofSize: 19, weight: .semibold),
                     editorDoneButtonFont: UIFont = .sourceSansProFont(ofSize: 19, weight: .semibold)) {
             self.tintColor = tintColor
             self.annotationFillColor = annotationFillColor
@@ -124,7 +124,7 @@ public struct InterfaceCustomization {
             self.feedbackBackButtonFont = feedbackBackButtonFont
             self.logCollectionPermissionFont = logCollectionPermissionFont
             self.editorTextAnnotationSegmentFont = editorTextAnnotationSegmentFont
-            self.editorTextAnnotationDoneButtonFont = editorTextAnnotationDoneButtonFont
+            self.editorTextAnnotationDismissButtonFont = editorTextAnnotationDismissButtonFont
             self.editorDoneButtonFont = editorDoneButtonFont
         }
     }


### PR DESCRIPTION
## What it Does

- Adds the ability to customize bar buttons on `EditImageViewController`
- Introduces a new `Appearance` property, `editorDoneButtonFont`, since the `editorTextAnnotationDoneButtonFont` was being used for more than just the text annotation dismiss button.
- Renames `editorTextAnnotationDoneButtonFont` to `editorTextAnnotationDismissButtonFont` for better disambiguation.

## How to Test

1. Run `git revert -n 0db8fa2`, which uses a custom implementation of `EditImageViewControllerBarButtonItemProviding`.
1. View the test code in `ViewController.swift`, which makes the right bar button item log to the console, and the left bar button item dismiss.
1. Make some modifications like setting `allowsHidingBarButtonItemsWhileEditingTextAnnotations` to `true` in this test implementation, and verify the results.