### PR TITLE
Updates to UIScreen Extension

### DIFF
--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
@@ -387,7 +387,7 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
 
         let imagePixelSize = CGSize(width: imageSize.width * imageScale, height: imageSize.height * imageScale)
         
-        let portraitPixelSize = UIScreen.main.portraitPixelSize()
+        let portraitPixelSize = UIScreen.main.portraitPixelSize
         return CGFloat(imagePixelSize.width) == portraitPixelSize.height && CGFloat(imagePixelSize.height) == portraitPixelSize.width
     }
     

--- a/PinpointKit/PinpointKit/Sources/Core/Screen.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Screen.swift
@@ -8,15 +8,16 @@
 
 import UIKit
 
-/// Extends `UIScreen` to identify the pixel size for a screen.
+/// Extends `UIScreen` to add convenience properties.
 extension UIScreen {
     
-    /**
-     Identifies the size of the pixel when the screen is in portrait.
-     
-     - returns: The size of a pixel for the screen's portrait dimensions.
-     */
-    func portraitPixelSize() -> CGSize {
+    /// The height of a single pixel on the screen, in points.
+    var pixelHeight: CGFloat {
+        return 1.0 / scale
+    }
+    
+    /// The size of the receiver when in portrait orientation.
+    var portraitPixelSize: CGSize {
         let coordinateSpaceBounds = fixedCoordinateSpace.bounds
         
         return CGSize(width: coordinateSpaceBounds.width * scale, height: coordinateSpaceBounds.height * scale)

--- a/PinpointKit/PinpointKit/Sources/Core/ScreenshotCell.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/ScreenshotCell.swift
@@ -103,7 +103,7 @@ class ScreenshotCell: UITableViewCell {
     
     override func addSubview(_ view: UIView) {
         // Prevents the adding of separators to this cell.
-        let separatorHeight = 1.0 / UIScreen.main.scale
+        let separatorHeight = UIScreen.main.pixelHeight
         guard view.frame.height != separatorHeight else {
             return
         }


### PR DESCRIPTION
## What it Does

- In #180, a Swift 2.3-specific change, I was asked to add a `UIScreen` extension for `pixelHeight`, to be used in `ScreenshotCell.swift`. I’m adding that here since it was a good suggestion.
- Corrects the documentation of `portraitPixelSize` and makes it a `var` which seems more appropriate.

## How to Test

Ensuring single-pixel separator views don’t appear on the screenshot cell.