### PR TITLE
Adds Default Implementation of `editorWillDismiss(_:with:)`

### DIFF
--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditorDelegate.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditorDelegate.swift
@@ -14,6 +14,8 @@ public protocol EditorDelegate: class {
      
      - parameter editor: The editor resonsible for editing the image.
      - parameter screenshot: The edited image of a screenshot.
+     
+     - note: The default implementation of this method does nothing.
      */
     func editorDidMakeChange(_ editor: Editor, to screenshot: UIImage)
     
@@ -23,7 +25,7 @@ public protocol EditorDelegate: class {
      - parameter editor: The editor resonsible for editing the image.
      - parameter screenshot: The edited image of a screenshot, after editing is complete.
      
-     - returns: A bool value that defines if the editor dismisses or not.
+     - returns: A bool value that defines if the editor dismisses or not. The default implementation of this method returns `true`.
      */
     func editorShouldDismiss(_ editor: Editor, with screenshot: UIImage) -> Bool
     
@@ -32,6 +34,8 @@ public protocol EditorDelegate: class {
      
      - parameter editor: The editor resonsible for editing the image.
      - parameter screenshot: The edited image of a screenshot, after editing is complete.
+     
+     - note: The default implementation of this method does nothing.
      */
     func editorWillDismiss(_ editor: Editor, with screenshot: UIImage)
     
@@ -40,6 +44,8 @@ public protocol EditorDelegate: class {
      
      - parameter editor: The editor resonsible for editing the image.
      - parameter screenshot: The edited image of a screenshot, after editing is complete.
+     
+     - note: The default implementation of this method does nothing.
      */
     func editorDidDismiss(_ editor: Editor, with screenshot: UIImage)
 }

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditorDelegate.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditorDelegate.swift
@@ -55,6 +55,10 @@ extension EditorDelegate {
         return true
     }
     
+    func editorWillDismiss(_ editor: Editor, with screenshot: UIImage) {
+        // Do nothing
+    }
+    
     public func editorDidDismiss(_ editor: Editor, with screenshot: UIImage) {
         // Do nothing
     }


### PR DESCRIPTION
Adds a default implementation for `editorWillDismiss(_:with:)` so clients need not add a stub.