### PR TITLE
Improvements to EditorDelegate

### DIFF
--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import CoreImage
 
 /// The default view controller responsible for editing an image.
-public final class EditImageViewController: UIViewController, UIGestureRecognizerDelegate {
+public class EditImageViewController: UIViewController, UIGestureRecognizerDelegate {
     private static let TextViewEditingBarAnimationDuration = 0.25
     
     // MARK: - Editor

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
@@ -437,6 +437,10 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
     }
     
     @objc private func toolChanged(_ segmentedControl: UISegmentedControl) {
+        if let tool = currentTool {
+            delegate?.editor(_editor: self, didSelect: tool)
+        }
+        
         endEditingTextView()
         
         // Disable the bar hiding behavior when selecting the text tool. Enable for all others.

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
@@ -105,12 +105,14 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
     private var currentAnnotationView: AnnotationView? {
         didSet {
             if let oldTextAnnotationView = oldValue as? TextAnnotationView {
+                NotificationCenter.default.removeObserver(self, name: .UITextViewTextDidChange, object: oldTextAnnotationView.textView)
                 NotificationCenter.default.removeObserver(self, name: .UITextViewTextDidEndEditing, object: oldTextAnnotationView.textView)
             }
             
             if let currentTextAnnotationView = currentTextAnnotationView {
                 keyboardAvoider?.triggerViews = [currentTextAnnotationView.textView]
                 
+                NotificationCenter.default.addObserver(self, selector: #selector(EditImageViewController.textViewTextDidChange), name: .UITextViewTextDidChange, object: currentTextAnnotationView.textView)
                 NotificationCenter.default.addObserver(self, selector: #selector(EditImageViewController.forceEndEditingTextView), name: .UITextViewTextDidEndEditing, object: currentTextAnnotationView.textView)
             }
         }
@@ -327,9 +329,14 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
             let annotationViewIsNotBlurView = !(possibleAnnotationView is BlurAnnotationView)
             
             if let annotationView = possibleAnnotationView {
+                let wasTopmostAnnotationView = (annotationsView.subviews.last == annotationView)
                 annotationsView.bringSubview(toFront: annotationView)
                 
                 if annotationViewIsNotBlurView {
+                    if !wasTopmostAnnotationView {
+                        informDelegate(of: .broughtToFront)
+                    }
+                    
                     navigationController?.barHideOnTapGestureRecognizer.failRecognizing()
                 }
             }
@@ -405,6 +412,10 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         navigationItem.setLeftBarButton(nil, animated: true)
     }
     
+    @objc private func textViewTextDidChange() {
+        informDelegate(of: .textEdited)
+    }
+    
     @objc private func forceEndEditingTextView() {
         endEditingTextView(false)
     }
@@ -417,8 +428,9 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         if let textView = currentTextAnnotationView?.textView, !checksFirstResponder || textView.isFirstResponder {
             textView.resignFirstResponder()
             
-            if !textView.hasText {
+            if !textView.hasText && currentTextAnnotationView?.superview != nil {
                 currentTextAnnotationView?.removeFromSuperview()
+                informDelegate(of: .deleted(animated: false))
             }
             
             navigationItem.setLeftBarButton(barButtonItemProvider?.leftBarButtonItem, animated: true)
@@ -432,8 +444,6 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         currentBlurAnnotationView?.drawsBorder = false
         let isEditingTextView = currentTextAnnotationView?.textView.isFirstResponder ?? false
         currentAnnotationView = isEditingTextView ? currentAnnotationView : nil
-        
-        informDelegateOfChange()
     }
     
     @objc private func toolChanged(_ segmentedControl: UISegmentedControl) {
@@ -467,7 +477,14 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
             handleCreateAnnotationGestureRecognizerBegan(gestureRecognizer)
         case .changed:
             handleCreateAnnotationGestureRecognizerChanged(gestureRecognizer)
-        case .cancelled, .failed, .ended:
+        case .ended:
+            handleGestureRecognizerFinished()
+            
+            // We inform the delegate of text annotation view creation on initial creation.
+            if !(currentAnnotationView is TextAnnotationView) {
+                informDelegate(of: .added)
+            }
+        case .cancelled, .failed:
             handleGestureRecognizerFinished()
         default:
             break
@@ -489,7 +506,11 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         annotationsView.addSubview(view)
         currentAnnotationView = view
-        beginEditingTextView()
+        
+        if currentAnnotationView is TextAnnotationView {
+            beginEditingTextView()
+            informDelegate(of: .added)
+        }
     }
     
     private func handleCreateAnnotationGestureRecognizerChanged(_ gestureRecognizer: UIPanGestureRecognizer) {
@@ -505,7 +526,10 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
             handleUpdateAnnotationGestureRecognizerBegan(gestureRecognizer)
         case .changed:
             handleUpdateAnnotationGestureRecognizerChanged(gestureRecognizer)
-        case .cancelled, .failed, .ended:
+        case .ended:
+            handleGestureRecognizerFinished()
+            informDelegate(of: .moved)
+        case .cancelled, .failed:
             handleGestureRecognizerFinished()
         default:
             break
@@ -549,7 +573,14 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
             handleUpdateAnnotationPinchGestureRecognizerBegan(gestureRecognizer)
         case .changed:
             handleUpdateAnnotationPinchGestureRecognizerChanged(gestureRecognizer)
-        case .cancelled, .failed, .ended:
+        case .ended:
+            // Ensure we’re actually editing an annotation before notifying the delegate.
+            // Also, text annotations are not resizable.
+            if currentTextAnnotationView == nil && currentAnnotationView != nil {
+                informDelegate(of: .resized)
+            }
+            handleGestureRecognizerFinished()
+        case .cancelled, .failed:
             handleGestureRecognizerFinished()
         default:
             break
@@ -604,17 +635,18 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         let removeAnnotationView = {
             self.endEditingTextView()
             annotationView.removeFromSuperview()
-            
-            self.informDelegateOfChange()
         }
         
         if animated {
+            informDelegate(of: .deleted(animated: true))
+            
             UIView.perform(.delete, on: [annotationView], options: [], animations: nil) { finished in
                 removeAnnotationView()
             }
             
         } else {
             removeAnnotationView()
+            informDelegate(of: .deleted(animated: false))
         }
     }
     
@@ -624,11 +656,11 @@ public final class EditImageViewController: UIViewController, UIGestureRecognize
         }
     }
     
-    private func informDelegateOfChange() {
+    private func informDelegate(of change: AnnotationChange) {
         guard let delegate = delegate else { return }
         guard let image = imageView.image else { assertionFailure(); return }
         
-        delegate.editorDidMakeChange(self, to: image)
+        delegate.editor(self, didMake: change, to: image)
     }
     
     // MARK: - UIGestureRecognizerDelegate

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import CoreImage
 
 /// The default view controller responsible for editing an image.
-public class EditImageViewController: UIViewController, UIGestureRecognizerDelegate {
+public final class EditImageViewController: UIViewController, UIGestureRecognizerDelegate {
     private static let TextViewEditingBarAnimationDuration = 0.25
     
     // MARK: - Editor

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditorDelegate.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditorDelegate.swift
@@ -70,6 +70,7 @@ extension EditorDelegate {
     
     public func editor(_ editor: Editor, didMake change: AnnotationChange, to screenshot: UIImage) {
         // Do nothing
+        print(change)
     }
     
     public func editorShouldDismiss(_ editor: Editor, with screenshot: UIImage) -> Bool {

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditorDelegate.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditorDelegate.swift
@@ -23,11 +23,12 @@ public protocol EditorDelegate: class {
      A method that is called any time the editor makes a modification to the screenshot.
      
      - parameter editor: The editor resonsible for editing the image.
+     - parameter change: The change that was made to the screenshot.
      - parameter screenshot: The edited image of a screenshot.
      
      - note: The default implementation of this method does nothing.
      */
-    func editorDidMakeChange(_ editor: Editor, to screenshot: UIImage)
+    func editor(_ editor: Editor, didMake change: AnnotationChange, to screenshot: UIImage)
     
     /**
      A method that is called with an image to ask if the editor should be dismissed.
@@ -67,7 +68,7 @@ extension EditorDelegate {
         // Do nothing
     }
     
-    public func editorDidMakeChange(_ editor: Editor, to screenshot: UIImage) {
+    public func editor(_ editor: Editor, didMake change: AnnotationChange, to screenshot: UIImage) {
         // Do nothing
     }
     
@@ -82,4 +83,26 @@ extension EditorDelegate {
     public func editorDidDismiss(_ editor: Editor, with screenshot: UIImage) {
         // Do nothing
     }
+}
+
+/// Represents a change made using the editor.
+public enum AnnotationChange {
+    
+    /// An annotation was added.
+    case added
+    
+    /// An annotation was moved.
+    case moved
+    
+    /// An annotation was brought to front.
+    case broughtToFront
+    
+    /// An annotation was resized.
+    case resized
+    
+    /// A text annotation was edited.
+    case textEdited
+    
+    /// An annotation was deleted. `animated` represents whether the deletion is animated.
+    case deleted(animated: Bool)
 }

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditorDelegate.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditorDelegate.swift
@@ -10,6 +10,16 @@
 public protocol EditorDelegate: class {
     
     /**
+     A method that is called when the tool selection changes in the editor.
+     
+     - parameter editor: The editor responsible for editing the image.
+     - parameter tool: The tool that was selected.
+     
+     - note: The default implementation of this method does nothing.
+     */
+    func editor(_editor: Editor, didSelect tool: Tool)
+    
+    /**
      A method that is called any time the editor makes a modification to the screenshot.
      
      - parameter editor: The editor resonsible for editing the image.
@@ -52,6 +62,10 @@ public protocol EditorDelegate: class {
 
 /// Extends editor delegate with base implementation for functions.
 extension EditorDelegate {
+    
+    public func editor(_editor: Editor, didSelect tool: Tool) {
+        // Do nothing
+    }
     
     public func editorDidMakeChange(_ editor: Editor, to screenshot: UIImage) {
         // Do nothing

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditorDelegate.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditorDelegate.swift
@@ -70,7 +70,6 @@ extension EditorDelegate {
     
     public func editor(_ editor: Editor, didMake change: AnnotationChange, to screenshot: UIImage) {
         // Do nothing
-        print(change)
     }
     
     public func editorShouldDismiss(_ editor: Editor, with screenshot: UIImage) -> Bool {

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/Tool.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/Tool.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// Represents an editing tool.
-enum Tool: Int {
+public enum Tool: Int {
     
     /// The arrow tool.
     case arrow


### PR DESCRIPTION
## What it Does

This PR improves the `EditorDelegate` and updates `EditImageViewController` to call the appropriate delegate methods. `EditorDelegate` now:

- Is notified of tool selection changes.
- Is notified of more granular changes. Previously, we notified the delegate simply that a change was made. Now we provide more information about the change.

## How to Test

1. `git revert -n d7a82dc`
1. With the simulator running, make all of the different types of `AnnotationChange`s to ensure that the appropriate change is logged to the console.