### PR TITLE
Makes `ScreenshotDetector`’s `init` Public

### DIFF
--- a/PinpointKit/PinpointKit/Sources/ScreenshotDetector/ScreenshotDetector.swift
+++ b/PinpointKit/PinpointKit/Sources/ScreenshotDetector/ScreenshotDetector.swift
@@ -42,7 +42,7 @@ open class ScreenshotDetector: NSObject {
      - parameter application:        An application that will be the `object` of the notification observer.
      - parameter imageManager:       An image manager used to fetch the image data of the screenshot.
      */
-    init(delegate: ScreenshotDetectorDelegate, notificationCenter: NotificationCenter = .default, application: UIApplication = .shared, imageManager: PHImageManager = .default()) {
+    public init(delegate: ScreenshotDetectorDelegate, notificationCenter: NotificationCenter = .default, application: UIApplication = .shared, imageManager: PHImageManager = .default()) {
         self.delegate = delegate
         self.notificationCenter = notificationCenter
         self.application = application


### PR DESCRIPTION
Follow-up to #199.

## What it Does

Makes `ScreenshotDetector`’s `init` Public. Otherwise, you can’t instantiate `ScreenshotDetector` in your own code.

## How to Test

* Create a new Single View Application Xcode project called `Screenshot`
* In Terminal (in the root of the project), run `pod init`
* Run `open Podfile -a Xcode`
* Replace the contents with:
```
target 'Screenshot' do
  use_frameworks!

  # Pods for Screenshot
  pod 'PinpointKit', :git => 'https://github.com/Lickability/PinpointKit.git', :branch => 'screenshot-detector-public-init'
  pod 'PinpointKit/ScreenshotDetector', :git => 'https://github.com/Lickability/PinpointKit.git', :branch => 'screenshot-detector-public-init'
end
```
* Run `pod install`
* Close the project and open the workspace
* Open `Info.plist` and add an entry for `NSPhotoLibraryUsageDescription`
* Replace `ViewController.swift`’s contents with:
```swift
import UIKit
import PinpointKit

class ViewController: UIViewController {
    
    let pinpointKit = PinpointKit(feedbackRecipients: ["hey@example.com"])
    var screenshotDetector: ScreenshotDetector?
    
    override func viewDidLoad() {
        super.viewDidLoad()
        
        screenshotDetector = ScreenshotDetector(delegate: self)
    }
}

extension ViewController: ScreenshotDetectorDelegate {
    
    func screenshotDetector(_ screenshotDetector: ScreenshotDetector, didDetect screenshot: UIImage) {
        pinpointKit.show(from: self)
    }
    
    func screenshotDetector(_ screenshotDetector: ScreenshotDetector, didFailWith error: ScreenshotDetector.Error) {
        print("error")
    }
}
```
* Run the app on a device and take a screenshot. PinpointKit’s interface should appear.
* In `ScreenshotDetector.swift`, remove `public` from `init`. You should see an error: `ViewController.swift:20:30: 'ScreenshotDetector' initializer is inaccessible due to 'internal' protection level`, which shows the necessity for this proposed change.