### PR TITLE
Hides Default Logging Capabilities on iOS 10+

### DIFF
--- a/PinpointKit/PinpointKit/Sources/Core/FeedbackTableViewDataSource.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/FeedbackTableViewDataSource.swift
@@ -47,7 +47,7 @@ final class FeedbackTableViewDataSource: NSObject, UITableViewDataSource {
     // MARK: - FeedbackTableViewDataSource
     
     private static func sectionsFromConfiguration(_ interfaceCustomization: InterfaceCustomization, screenshot: UIImage, logSupporting: LogSupporting, userEnabledLogCollection: Bool) -> [Section] {
-        var sections = [Section]()
+        var sections: [Section] = []
         
         let screenshotRow = Row.screenshot(screensot: screenshot, hintText: interfaceCustomization.interfaceText.feedbackEditHint, hintFont: interfaceCustomization.appearance.feedbackEditHintFont)
         let screenshotSection = Section.feedback(rows: [screenshotRow])

--- a/PinpointKit/PinpointKit/Sources/Core/FeedbackTableViewDataSource.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/FeedbackTableViewDataSource.swift
@@ -47,15 +47,21 @@ final class FeedbackTableViewDataSource: NSObject, UITableViewDataSource {
     // MARK: - FeedbackTableViewDataSource
     
     private static func sectionsFromConfiguration(_ interfaceCustomization: InterfaceCustomization, screenshot: UIImage, logSupporting: LogSupporting, userEnabledLogCollection: Bool) -> [Section] {
-        guard logSupporting.logCollector != nil else { return [] }
+        var sections = [Section]()
         
         let screenshotRow = Row.screenshot(screensot: screenshot, hintText: interfaceCustomization.interfaceText.feedbackEditHint, hintFont: interfaceCustomization.appearance.feedbackEditHintFont)
         let screenshotSection = Section.feedback(rows: [screenshotRow])
         
-        let collectLogsRow = Row.collectLogs(enabled: userEnabledLogCollection, title: interfaceCustomization.interfaceText.logCollectionPermissionTitle, font: interfaceCustomization.appearance.logCollectionPermissionFont, canView: logSupporting.logViewer != nil)
-        let collectLogsSection = Section.feedback(rows: [collectLogsRow])
+        sections.append(screenshotSection)
         
-        return [screenshotSection, collectLogsSection]
+        if logSupporting.logCollector != nil {
+            let collectLogsRow = Row.collectLogs(enabled: userEnabledLogCollection, title: interfaceCustomization.interfaceText.logCollectionPermissionTitle, font: interfaceCustomization.appearance.logCollectionPermissionFont, canView: logSupporting.logViewer != nil)
+            let collectLogsSection = Section.feedback(rows: [collectLogsRow])
+            
+            sections.append(collectLogsSection)
+        }
+        
+        return sections
     }
     
     private func checkmarkCell(for row: Row) -> CheckmarkCell {

--- a/PinpointKit/PinpointKit/Sources/Core/SystemLogCollector.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/SystemLogCollector.swift
@@ -22,7 +22,19 @@ open class SystemLogCollector: LogCollector {
     
     private let logger: ASLLogger
     
-    public init(loggingType: LoggingType = .application) {
+    /**
+     Creates a new system logger.
+     
+     - parameter loggingType: Specifies the type of logs to collect.
+     
+     - warning: This initializer returns `nil` on iOS 10.0+. When running on iOS 10.0+, ASL is superseded by unified logging, for which there are no APIs to search or read log messages.
+     - seealso: https://developer.apple.com/reference/os/logging
+     */
+    public init?(loggingType: LoggingType = .application) {
+        if #available(iOS 10.0, *) {
+            return nil
+        }
+        
         switch loggingType {
         case .application:
             logger = ASLLogger(bundleIdentifier: Bundle.main.bundleIdentifier ?? "")

--- a/PinpointKit/PinpointKit/Sources/Core/SystemLogCollector.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/SystemLogCollector.swift
@@ -31,7 +31,7 @@ open class SystemLogCollector: LogCollector {
      - seealso: https://developer.apple.com/reference/os/logging
      */
     public init?(loggingType: LoggingType = .application) {
-        if #available(iOS 10.0, *) {
+        if #available(iOS 10.0, *), loggingType == .application {
             return nil
         }
         

--- a/PinpointKit/PinpointKitTests/SystemLogCollectorTests.swift
+++ b/PinpointKit/PinpointKitTests/SystemLogCollectorTests.swift
@@ -23,9 +23,9 @@ class SystemLogCollectorTests: XCTestCase {
         
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
             
-            let logs = systemLogCollector.retrieveLogs()
+            let systemLogs = systemLogCollector?.retrieveLogs()
             
-            guard let firstLog = logs.first else { return XCTFail("There should be at least 1 log.") }
+            guard let logs = systemLogs, let firstLog = logs.first else { return XCTFail("There should be at least 1 log.") }
             
             XCTAssertEqual(logs.count, 3)
             XCTAssertTrue(firstLog.contains(testString))
@@ -49,9 +49,9 @@ class SystemLogCollectorTests: XCTestCase {
         let expectation = defaultExpectation()
         
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
-            let logs = systemLogCollector.retrieveLogs()
+            let systemLogs = systemLogCollector?.retrieveLogs()
             
-            guard logs.count == 3 else { return XCTFail("Count should be 3.") }
+            guard let logs = systemLogs, logs.count == 3 else { return XCTFail("Count should be 3.") }
             
             let firstLog = logs[0]
             let secondLog = logs[1]
@@ -74,14 +74,14 @@ class SystemLogCollectorTests: XCTestCase {
 
         let systemLogCollector = SystemLogCollector(loggingType: .testing)
         
-        XCTAssertEqual(systemLogCollector.retrieveLogs().count, 0)
+        XCTAssertEqual(systemLogCollector?.retrieveLogs().count, 0)
     }
     
     func testLogCollectorHasNoLogsInitially() {
         let systemLogCollector = SystemLogCollector(loggingType: .testing)
         
-        let logs = systemLogCollector.retrieveLogs()
+        let logs = systemLogCollector?.retrieveLogs()
         
-        XCTAssertEqual(logs.count, 0)
+        XCTAssertEqual(logs?.count, 0)
     }
 }


### PR DESCRIPTION
Closes #205.

## What it Does

See description of issue at #205, and the `- warning:` on the initializer in code. This prevents the logging section/cell from displaying on devices that can’t use ASL.

The rest of the code to support logging is in place, and if a 3rd-party logging system were used, it could be made to conform to `LogCollector` and replace `SystemLogCollector` via customization.

## How to Test

1. Run the Example project on an iOS 9.x device
1. Ensure the logging cell is there, and tapping the accessory button takes you to the log view controller with the test log present.
Ensure that logs.txt is attached to an email when sending feedback.
1. Run the Example project on an iOS 10.0 device
1. Ensure the log cell is not present at all, and no logs.txt i