### PR TITLE
ScreenshotDetector Fixes

### DIFF
--- a/PinpointKit/PinpointKit/Sources/ScreenshotDetector/ScreenshotDetector.swift
+++ b/PinpointKit/PinpointKit/Sources/ScreenshotDetector/ScreenshotDetector.swift
@@ -33,6 +33,7 @@ open class ScreenshotDetector: NSObject {
     private let notificationCenter: NotificationCenter
     private let application: UIApplication
     private let imageManager: PHImageManager?
+    fileprivate let photoLibrary: PHPhotoLibrary
     
     /**
      Initializes a `ScreenshotDetector` with its dependencies. Note that `ScreenshotDetector` requires access to the user’s Photo Library and it will request this access if your application does not already have it.
@@ -41,12 +42,14 @@ open class ScreenshotDetector: NSObject {
      - parameter notificationCenter: A notification center that will listen for screenshot notifications.
      - parameter application:        An application that will be the `object` of the notification observer.
      - parameter imageManager:       An image manager used to fetch the image data of the screenshot. If `nil`, the `default()` image manager will be used.
+     - parameter photoLibrary:       The photo library used for detecting a change event after a screenshot is taken. Defaults to `.shared()`.
      */
-    public init(delegate: ScreenshotDetectorDelegate, notificationCenter: NotificationCenter = .default, application: UIApplication = .shared, imageManager: PHImageManager? = nil) {
+    public init(delegate: ScreenshotDetectorDelegate, notificationCenter: NotificationCenter = .default, application: UIApplication = .shared, imageManager: PHImageManager? = nil, photoLibrary: PHPhotoLibrary = .shared()) {
         self.delegate = delegate
         self.notificationCenter = notificationCenter
         self.application = application
         self.imageManager = imageManager
+        self.photoLibrary = photoLibrary
         
         super.init()
         
@@ -64,7 +67,9 @@ open class ScreenshotDetector: NSObject {
             OperationQueue.main.addOperation {
                 switch authorizationStatus {
                 case .authorized:
-                    self.findScreenshot()
+                    // Register for the next photo library change notification since the new screenshot
+                    // won’t be available immediately.
+                    self.photoLibrary.register(self)
                 case .denied, .notDetermined, .restricted:
                     self.fail(with: .unauthorized(status: authorizationStatus))
                 }
@@ -72,7 +77,7 @@ open class ScreenshotDetector: NSObject {
         }
     }
     
-    private func findScreenshot() {
+    fileprivate func findScreenshot() {
         guard let screenshot = PHAsset.fetchLastScreenshot() else { fail(with: .fetchFailure); return }
         
         // Fall back to the `.default()` image manager if an image manager wasn’t set on initialization.
@@ -126,7 +131,7 @@ public protocol ScreenshotDetectorDelegate: class {
 
 @available(iOS 9.0, *)
 private extension PHAsset {
-
+    
     static func fetchLastScreenshot() -> PHAsset? {
         let options = PHFetchOptions()
         
@@ -150,5 +155,15 @@ private extension PHImageRequestOptions {
         options.isSynchronous = true
         
         return options
+    }
+}
+
+extension ScreenshotDetector: PHPhotoLibraryChangeObserver {
+    
+    // MARK: - PHPhotoLibraryChangeObserver
+    
+    public func photoLibraryDidChange(_ changeInstance: PHChange) {
+        photoLibrary.unregisterChangeObserver(self)
+        findScreenshot()
     }
 }

--- a/PinpointKit/PinpointKit/Sources/ScreenshotDetector/ScreenshotDetector.swift
+++ b/PinpointKit/PinpointKit/Sources/ScreenshotDetector/ScreenshotDetector.swift
@@ -32,7 +32,7 @@ open class ScreenshotDetector: NSObject {
     private weak var delegate: ScreenshotDetectorDelegate?
     private let notificationCenter: NotificationCenter
     private let application: UIApplication
-    private let imageManager: PHImageManager
+    private let imageManager: PHImageManager?
     
     /**
      Initializes a `ScreenshotDetector` with its dependencies. Note that `ScreenshotDetector` requires access to the user’s Photo Library and it will request this access if your application does not already have it.
@@ -40,9 +40,9 @@ open class ScreenshotDetector: NSObject {
      - parameter delegate:           The delegate that will be notified when detection succeeds or fails.
      - parameter notificationCenter: A notification center that will listen for screenshot notifications.
      - parameter application:        An application that will be the `object` of the notification observer.
-     - parameter imageManager:       An image manager used to fetch the image data of the screenshot.
+     - parameter imageManager:       An image manager used to fetch the image data of the screenshot. If `nil`, the `default()` image manager will be used.
      */
-    public init(delegate: ScreenshotDetectorDelegate, notificationCenter: NotificationCenter = .default, application: UIApplication = .shared, imageManager: PHImageManager = .default()) {
+    public init(delegate: ScreenshotDetectorDelegate, notificationCenter: NotificationCenter = .default, application: UIApplication = .shared, imageManager: PHImageManager? = nil) {
         self.delegate = delegate
         self.notificationCenter = notificationCenter
         self.application = application
@@ -74,6 +74,11 @@ open class ScreenshotDetector: NSObject {
     
     private func findScreenshot() {
         guard let screenshot = PHAsset.fetchLastScreenshot() else { fail(with: .fetchFailure); return }
+        
+        // Fall back to the `.default()` image manager if an image manager wasn’t set on initialization.
+        // We don’t specify this as a default parameter to the initializer since calling `.default()`
+        // immediately prompts the user for access to the photo library, before we even need to use it.
+        let imageManager: PHImageManager = self.imageManager ?? .default()
         
         imageManager.requestImage(for: screenshot,
             targetSize: PHImageManagerMaximumSize,


### PR DESCRIPTION
Closes #211

## What It Does

Fixes two issues with `ScreenshotDetector` brought up in #211:

1. The permission alert for accessing the user’s photo library was appearing prematurely. Now it appears at the time we need to first access the photo library.
1. The fetched screenshot delivered in the delegate was the second-to-most-recent screenshot in the user’s library. We now wait for a change to the photo library before fetching the screenshot to deliver.

## How to Test

* Create a new "Single View Application" in Xcode
* In Terminal.app, `cd` to its directory, and run `pod init`
* Open the Podfile and add the following two lines within your target:

```
  pod 'PinpointKit', :git => 'https://github.com/Lickability/PinpointKit.git', :branch => 'screenshot-detector-fixes'
  pod 'PinpointKit/ScreenshotDetector', :git => 'https://github.com/Lickability/PinpointKit.git', :branch => 'screenshot-detector-fixes'
```
* Run `pod install`
* Close the Xcode project and open the newly created workspace
* Add an entry for `NSPhotoLibraryUsageDescription` in `Info.plist`
* Replace the contents of `ViewController.swift` with the following:
```swift
import UIKit
import PinpointKit

class ViewController: UIViewController {
    private var screenshotDetector: ScreenshotDetector?
    fileprivate let pinpointKit = PinpointKit(feedbackRecipients: ["feedback@example.com"])
    
    override func viewDidLoad() {
        super.viewDidLoad()
        
        screenshotDetector = ScreenshotDetector(delegate: self)
    }
}

extension ViewController: ScreenshotDetectorDelegate {
    
    func screenshotDetector(_ screenshotDetector: ScreenshotDetector, didFailWith error: ScreenshotDetector.Error) {
        print(error)
    }
    
    func screenshotDetector(_ screenshotDetector: ScreenshotDetector, didDetect screenshot: UIImage) {
        pinpointKit.show(from: self, screenshot: screenshot)
    }
}
```
* Run the app on a device, noticing that you’re not immediately prompted for access to your photo library
* Make note of the time in the status bar
* Take a screenshot and accept the correctly-timed prompt
* Confirm that the time you noted matches that of the screenshot presented by PinpointKit
* Repeat taking screenshots until you’re satisfied that the latest screenshot is always used

## Notes

Thanks to @iosdeveloper for finding these.