### PR TITLE
Fixes Swift Swift 3.2 Compiler Error

### DIFF
--- a/PinpointKit/PinpointKit/Sources/Core/Configuration.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Configuration.swift
@@ -60,20 +60,22 @@ public struct Configuration {
                 editor: Editor = EditImageViewController(),
                 sender: Sender = MailSender(),
                 feedbackConfiguration: FeedbackConfiguration) {
-        self.feedbackCollector = feedbackCollector
-        self.editor = editor
         
-        self.feedbackCollector.editor = editor
+        self.editor = editor
         
         self.sender = sender
         
         let interfaceCustomization = InterfaceCustomization(interfaceText: interfaceText, appearance: appearance)
         
-        self.feedbackCollector.interfaceCustomization = interfaceCustomization
-        self.feedbackCollector.logCollector = logCollector
-        self.feedbackCollector.logViewer = logViewer
-        self.feedbackCollector.logViewer?.interfaceCustomization = interfaceCustomization
-        self.feedbackCollector.editor?.interfaceCustomization = interfaceCustomization
-        self.feedbackCollector.feedbackConfiguration = feedbackConfiguration
+        var newFeedbackCollector = feedbackCollector
+        newFeedbackCollector.editor = editor
+        newFeedbackCollector.interfaceCustomization = interfaceCustomization
+        newFeedbackCollector.logCollector = logCollector
+        newFeedbackCollector.logViewer = logViewer
+        newFeedbackCollector.logViewer?.interfaceCustomization = interfaceCustomization
+        newFeedbackCollector.editor?.interfaceCustomization = interfaceCustomization
+        newFeedbackCollector.feedbackConfiguration = feedbackConfiguration
+        
+        self.feedbackCollector = newFeedbackCollector
     }
 }


### PR DESCRIPTION
Closes #222 

## What It Does

Fixes a compiler error caused by modifying `feedbackController`, a `let` constant, in `init` which used to be permitted.

## How to Test

In the latest Xcode 9 beta, run `PinpointKitExample` and smoke test. No compiler errors should occur.

## Notes

I’ve filed several other unrelated Xcode 9 / iOS 11 SDK issues, but if you see any others while on this branch in the beta, please let me know.