### PR TITLE
Add mail failure alert

### DIFF
--- a/PinpointKit/PinpointKit/Sources/Core/PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/PinpointKit.swift
@@ -83,7 +83,7 @@ extension PinpointKit: SenderDelegate {
     }
     
     public func sender(_ sender: Sender, didFailToSend feedback: Feedback?, error: Error) {
-        if case MailSender.Error.mailCanceled = error { return }        
+        if case MailSender.Error.mailCanceled = error { return }
         
         guard let feedback = feedback else { return }
         delegate?.pinpointKit(self, didFailToSend: feedback, error: error)

--- a/PinpointKit/PinpointKit/Sources/Core/PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/PinpointKit.swift
@@ -133,6 +133,6 @@ public extension PinpointKitDelegate {
         let okAction = UIAlertAction(title: "OK", style: .default, handler: nil)
         alert.addAction(okAction)
         
-        self.configuration.feedbackCollector.viewController.present(alert, animated: true, completion: nil)
+        pinpointKit.configuration.feedbackCollector.viewController.present(alert, animated: true, completion: nil)
     }
 }

--- a/PinpointKit/PinpointKit/Sources/Core/PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/PinpointKit.swift
@@ -126,8 +126,8 @@ public extension PinpointKitDelegate {
     
     func pinpointKit(_ pinpointKit: PinpointKit, didFailToSend feedback: Feedback, error: Error) {
         let alert = UIAlertController(
-            title: "Mailer error",
-            message: "Unable to prepare an email to send. Ensure that you have at least one email account set up.",
+            title: "Can’t Send Email",
+            message: "Make sure that you have at least one email account set up.",
             preferredStyle: .alert)
         
         let okAction = UIAlertAction(title: "OK", style: .default, handler: nil)


### PR DESCRIPTION
This brings the changes for #220 into `master`, with one code change to fix a variable reference. The original body of PR #220 is reproduced below for reference.

---

Closes #219.

## What It Does
Previously, if the user clicked `Send` and the `MailSender` experienced a failure (e.g. when there are no mail accounts set up), nothing would happen in the GUI. There was also no method in `PinpointKitDelegate` to correspond to `didFailToSend` in `SenderDelegate`.

This commit adds an alert popup to `PinpointKit` to solve the first problem, and a `didFailToSend` method to `PinpointKitDelegate` for the second. The latter takes the original `Error` as a parameter in case developers want to use it present more specific messages.

![simulator](https://cloud.githubusercontent.com/assets/13933679/26026468/56b2fc78-382e-11e7-816a-dfcba0abcc52.png)

## How to Test
Ensure that the mailer will encounter an error (the easiest way is to run the example app on a simulator with no email accounts set up) and click `Send`.

## Notes
None in particular.