### PR TITLE
Allows customization of modal presentation style

### DIFF
--- a/Example/PinpointKitExample/ViewController.swift
+++ b/Example/PinpointKitExample/ViewController.swift
@@ -11,10 +11,15 @@ import PinpointKit
 
 final class ViewController: UITableViewController {
     
-    fileprivate let pinpointKit = PinpointKit(feedbackRecipients: ["feedback@example.com"])
+    fileprivate var pinpointKit: PinpointKit?
     
     override func viewDidLoad() {
+        
         super.viewDidLoad()
+        
+        let feedbackConfiguration = FeedbackConfiguration(recipients: ["feedback@example.com"], presentationStyle: .formSheet)
+        let configuration = Configuration(feedbackConfiguration: feedbackConfiguration)
+        self.pinpointKit = PinpointKit(configuration: configuration)
         
         // Hides the infinite cells footer.
         tableView.tableFooterView = UIView()
@@ -23,6 +28,6 @@ final class ViewController: UITableViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        pinpointKit.show(from: self)
+        pinpointKit?.show(from: self)
     }
 }

--- a/Example/PinpointKitExample/ViewController.swift
+++ b/Example/PinpointKitExample/ViewController.swift
@@ -11,15 +11,10 @@ import PinpointKit
 
 final class ViewController: UITableViewController {
     
-    fileprivate var pinpointKit: PinpointKit?
+    fileprivate let pinpointKit = PinpointKit(feedbackRecipients: ["feedback@example.com"])
     
     override func viewDidLoad() {
-        
         super.viewDidLoad()
-        
-        let feedbackConfiguration = FeedbackConfiguration(recipients: ["feedback@example.com"], presentationStyle: .formSheet)
-        let configuration = Configuration(feedbackConfiguration: feedbackConfiguration)
-        self.pinpointKit = PinpointKit(configuration: configuration)
         
         // Hides the infinite cells footer.
         tableView.tableFooterView = UIView()
@@ -28,6 +23,6 @@ final class ViewController: UITableViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        pinpointKit?.show(from: self)
+        pinpointKit.show(from: self)
     }
 }

--- a/PinpointKit/PinpointKit/Sources/Core/FeedbackConfiguration.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/FeedbackConfiguration.swift
@@ -30,6 +30,9 @@ public struct FeedbackConfiguration {
     /// A dictionary of additional information provided by the application developer.
     public var additionalInformation: [String: AnyObject]?
     
+    /// The modal presentation style for the feedback collection screen.
+    public let presentationStyle: UIModalPresentationStyle
+    
     /**
      Initializes a `FeedbackConfiguration` with optional default values.
      
@@ -39,18 +42,21 @@ public struct FeedbackConfiguration {
      - parameter body:                   The default body text.
      - parameter logsFileName:           The file name of the logs text file.
      - parameter additionalInformation:  Any additional information you want to capture.
+     - parameter presentationStyle:      The modal presentation style for the the feedback collection screen.
      */
     public init(screenshotFileName: String = "Screenshot",
                 recipients: [String],
                 title: String? = FeedbackConfiguration.DefaultTitle,
                 body: String? = nil,
                 logsFileName: String = "logs",
-                additionalInformation: [String: AnyObject]? = nil) {
+                additionalInformation: [String: AnyObject]? = nil,
+                presentationStyle: UIModalPresentationStyle = .fullScreen) {
         self.screenshotFileName = screenshotFileName
         self.recipients = recipients
         self.title = title
         self.body = body
         self.logsFileName = logsFileName
         self.additionalInformation = additionalInformation
+        self.presentationStyle = presentationStyle
     }
 }

--- a/PinpointKit/PinpointKit/Sources/Core/FeedbackNavigationController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/FeedbackNavigationController.swift
@@ -122,7 +122,7 @@ public final class FeedbackNavigationController: UINavigationController, Feedbac
         
         feedbackViewController.screenshot = screenshot
         feedbackViewController.annotatedScreenshot = screenshot
-
+        self.modalPresentationStyle = feedbackConfiguration?.presentationStyle ?? .fullScreen
         viewController.present(self, animated: true, completion: nil)
     }
 }

--- a/PinpointKit/PinpointKit/Sources/Core/FeedbackViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/FeedbackViewController.swift
@@ -193,6 +193,7 @@ extension FeedbackViewController: FeedbackCollector {
 extension FeedbackViewController: EditorDelegate {
     public func editorWillDismiss(_ editor: Editor, with screenshot: UIImage) {
         annotatedScreenshot = screenshot
+        tableView.reloadData()
     }
 }
 
@@ -236,6 +237,7 @@ extension FeedbackViewController: FeedbackTableViewDataSourceDelegate {
         
         let editImageViewController = NavigationController(rootViewController: editor.viewController)
         editImageViewController.view.tintColor = interfaceCustomization?.appearance.tintColor
+        editImageViewController.modalPresentationStyle = feedbackConfiguration?.presentationStyle ?? .fullScreen
         present(editImageViewController, animated: true, completion: nil)
     }
 }

--- a/PinpointKit/PinpointKit/Sources/Core/NavigationController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/NavigationController.swift
@@ -21,7 +21,6 @@ final class NavigationController: UINavigationController, UINavigationController
     override init(rootViewController: UIViewController) {
         super.init(rootViewController: rootViewController)
         delegate = self
-        modalPresentationStyle = .fullScreen // Necessary for proper transition rotation.
         modalPresentationCapturesStatusBarAppearance = true
     }
 


### PR DESCRIPTION
Adds presentation style to feedback configuration.
Reloads tableView upon dismissing the editor.

## What It Does
This PR allows the customisation of the FeedbackView/NavigationController's `modalPresentationStyle` (current default is `fullScreen`). I added the property `presentationStyle` to the `Feedback's Configuration` struct (defaults like before to `fullScreen`).

Furthermore we added a tableView reload to the `editorWillDismiss` callback so that not only the `annotedScreenshot` will be assigned, but also the new annoted screenshot will be shown by explicitly reloading the tableView. Using the previous 'fullScreen' presentationMode this wasn't necessary, since it that case the tableView was always implicitly reloaded.

## How to Test
Run the example application like before - it will be presented as a 'formSheet'.

## Notes
The reason for this change was the previous - hardcode - `fullScreen` modal presentation style. This results in the hiding of the calling `ViewController`. This might be fine for the most use(r)s, but in our case we need the `presentationStyle` `overFullscreen` / `overCurrentContext` - so that the calling `ViewController` will **not be hidden** as soon as the `FeedbackController` is been shown.