### PR TITLE
Small Fix to UIBarButtonItem+TitleTextAttributeStates

### DIFF
--- a/PinpointKit/PinpointKit/Sources/Core/UIBarButtonItem+TitleTextAttributeStates.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/UIBarButtonItem+TitleTextAttributeStates.swift
@@ -10,7 +10,7 @@ import UIKit
 /// Extends `UIBarButtonItem` to fix an issue with title text attribute propagation.
 extension UIBarButtonItem {
     
-    /// Sets the specified title text attributes for `.normal`, `.highlighted`, `.disabled`, and `.selected` control states.
+    /// Sets the specified title text attributes for `.normal`, `.highlighted`, `.disabled`, and `.focused` control states.
     ///
     /// - Parameter titleTextAttributes: A dictionary containing key-value pairs for text attributes.
     /// - Note: It should be enough to specify `.normal` and have the attributes propagate, but a bug (radar: 35221407) was introduced in iOS 11 which broke this functionality.
@@ -20,6 +20,6 @@ extension UIBarButtonItem {
         setTitleTextAttributes(titleTextAttributes, for: [.normal])
         setTitleTextAttributes(titleTextAttributes, for: [.highlighted])
         setTitleTextAttributes(titleTextAttributes, for: [.disabled])
-        setTitleTextAttributes(titleTextAttributes, for: [.selected])
+        setTitleTextAttributes(titleTextAttributes, for: [.focused])
     }
 }


### PR DESCRIPTION
## What It Does

Small follow-up to #244. The following was printing to the console:

> [Assert] button text attributes only respected for UIControlStateNormal, UIControlStateHighlighted, UIControlStateDisabled and UIControlStateFocused. state = 4 is interpreted as UIControlStateHighlighted.

I was using `.selected`, which is not respected, and have now changed it to `.focused`.

## How to Test

Same steps as #244 

## Notes

N/A