### PR TITLE
Fix for Showing the Mail Compose Failure Alert

### DIFF
--- a/PinpointKit/PinpointKit/Sources/Core/MailSender.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/MailSender.swift
@@ -60,10 +60,9 @@ open class MailSender: NSObject, Sender {
      - parameter viewController: The view controller from which to present any of the sender’s necessary views.
      */
     open func send(_ feedback: Feedback, from viewController: UIViewController?) {
-        guard let viewController = viewController else { fail(with: .noViewControllerProvided); return }
-        
         self.feedback = feedback
         
+        guard let viewController = viewController else { fail(with: .noViewControllerProvided); return }
         guard MFMailComposeViewController.canSendMail() else { fail(with: .mailCannotSend); return }
         
         let mailComposer = MFMailComposeViewController()

--- a/PinpointKit/PinpointKit/Sources/Core/MailSender.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/MailSender.swift
@@ -62,12 +62,12 @@ open class MailSender: NSObject, Sender {
     open func send(_ feedback: Feedback, from viewController: UIViewController?) {
         guard let viewController = viewController else { fail(with: .noViewControllerProvided); return }
         
+        self.feedback = feedback
+        
         guard MFMailComposeViewController.canSendMail() else { fail(with: .mailCannotSend); return }
         
         let mailComposer = MFMailComposeViewController()
         mailComposer.mailComposeDelegate = self
-        
-        self.feedback = feedback
         
         do {
             try mailComposer.attach(feedback)

--- a/PinpointKit/PinpointKit/Sources/Core/PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/PinpointKit.swift
@@ -62,12 +62,11 @@ open class PinpointKit {
     
     /// Presents an alert signifying the inability to compose a Mail message.
     open func presentFailureToComposeMailAlert() {
-        let alert = UIAlertController(
-            title: "Can’t Send Email",
-            message: "Make sure that you have at least one email account set up.",
-            preferredStyle: .alert)
+        let alertTitle = NSLocalizedString("Can’t Send Email", comment: "Title for an alert shown when attempting to send mail without a mail account setup.")
+        let alertMessage = NSLocalizedString("Make sure that you have at least one email account set up.", comment: "Message for an alert shown when attempting to send mail without a mail account setup.")
+        let alert = UIAlertController(title: alertTitle, message: alertMessage, preferredStyle: .alert)
         
-        let okAction = UIAlertAction(title: "OK", style: .default, handler: nil)
+        let okAction = UIAlertAction(title: NSLocalizedString("OK", comment: "OK button on mail send failure alert."), style: .default, handler: nil)
         alert.addAction(okAction)
         
         configuration.feedbackCollector.viewController.present(alert, animated: true, completion: nil)

--- a/PinpointKit/PinpointKit/Sources/Core/PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/PinpointKit.swift
@@ -64,12 +64,12 @@ open class PinpointKit {
     open func presentFailureToComposeMailAlert() {
         let alertTitle = NSLocalizedString("Can’t Send Email", comment: "Title for an alert shown when attempting to send mail without a mail account setup.")
         let alertMessage = NSLocalizedString("Make sure that you have at least one email account set up.", comment: "Message for an alert shown when attempting to send mail without a mail account setup.")
-        let alert = UIAlertController(title: alertTitle, message: alertMessage, preferredStyle: .alert)
+        let alertController = UIAlertController(title: alertTitle, message: alertMessage, preferredStyle: .alert)
         
         let okAction = UIAlertAction(title: NSLocalizedString("OK", comment: "OK button on mail send failure alert."), style: .default, handler: nil)
-        alert.addAction(okAction)
+        alertController.addAction(okAction)
         
-        configuration.feedbackCollector.viewController.present(alert, animated: true, completion: nil)
+        configuration.feedbackCollector.viewController.present(alertController, animated: true, completion: nil)
     }
 }
 


### PR DESCRIPTION
Closes #242 

## What It Does

Fixes the issue where tapping "Send" with no mail accounts, and no other configuration specified wouldn’t display the alert.

## How to Test

1. Run the example app in a clean simulator
1. Tap "Send"

## Notes

N/A
