### PR TITLE
Allow deeper customization

### DIFF
--- a/PinpointKit/PinpointKit/Resources/PinpointKit.xcassets/Segmented Control/ArrowIcon.imageset/Contents.json
+++ b/PinpointKit/PinpointKit/Resources/PinpointKit.xcassets/Segmented Control/ArrowIcon.imageset/Contents.json
@@ -2,13 +2,13 @@
   "images" : [
     {
       "idiom" : "universal",
-      "scale" : "1x",
-      "filename" : "ArrowIcon.png"
+      "filename" : "ArrowIcon.png",
+      "scale" : "1x"
     },
     {
       "idiom" : "universal",
-      "scale" : "2x",
-      "filename" : "ArrowIcon@2x.png"
+      "filename" : "ArrowIcon@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "universal",
@@ -18,5 +18,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/PinpointKit/PinpointKit/Resources/PinpointKit.xcassets/Segmented Control/BlurIcon.imageset/Contents.json
+++ b/PinpointKit/PinpointKit/Resources/PinpointKit.xcassets/Segmented Control/BlurIcon.imageset/Contents.json
@@ -2,13 +2,13 @@
   "images" : [
     {
       "idiom" : "universal",
-      "scale" : "1x",
-      "filename" : "BlurIcon.png"
+      "filename" : "BlurIcon.png",
+      "scale" : "1x"
     },
     {
       "idiom" : "universal",
-      "scale" : "2x",
-      "filename" : "BlurIcon@2x.png"
+      "filename" : "BlurIcon@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "universal",
@@ -18,5 +18,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/PinpointKit/PinpointKit/Resources/PinpointKit.xcassets/Segmented Control/BoxIcon.imageset/Contents.json
+++ b/PinpointKit/PinpointKit/Resources/PinpointKit.xcassets/Segmented Control/BoxIcon.imageset/Contents.json
@@ -2,13 +2,13 @@
   "images" : [
     {
       "idiom" : "universal",
-      "scale" : "1x",
-      "filename" : "BoxIcon.png"
+      "filename" : "BoxIcon.png",
+      "scale" : "1x"
     },
     {
       "idiom" : "universal",
-      "scale" : "2x",
-      "filename" : "BoxIcon@2x.png"
+      "filename" : "BoxIcon@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "universal",
@@ -18,5 +18,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/PinpointKit/PinpointKit/Sources/Core/FeedbackNavigationController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/FeedbackNavigationController.swift
@@ -125,4 +125,10 @@ public final class FeedbackNavigationController: UINavigationController, Feedbac
         self.modalPresentationStyle = feedbackConfiguration?.presentationStyle ?? .fullScreen
         viewController.present(self, animated: true, completion: nil)
     }
+
+    // MARK: - UINavigationController
+
+    public override var preferredStatusBarStyle: UIStatusBarStyle {
+        return topViewController?.preferredStatusBarStyle ?? .default
+    }
 }

--- a/PinpointKit/PinpointKit/Sources/Core/FeedbackViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/FeedbackViewController.swift
@@ -78,6 +78,12 @@ public final class FeedbackViewController: UITableViewController {
     }
     
     // MARK: - UIViewController
+
+    public override var preferredStatusBarStyle: UIStatusBarStyle {
+        guard let interfaceCustomization = interfaceCustomization else { assertionFailure(); return .default }
+        let appearance = interfaceCustomization.appearance
+        return appearance.statusBarStyle
+    }
     
     public override func viewDidLoad() {
         super.viewDidLoad()

--- a/PinpointKit/PinpointKit/Sources/Core/FeedbackViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/FeedbackViewController.swift
@@ -114,7 +114,10 @@ public final class FeedbackViewController: UITableViewController {
         let appearance = interfaceCustomization.appearance
 
         title = interfaceText.feedbackCollectorTitle
-        navigationController?.navigationBar.titleTextAttributes = [NSAttributedStringKey.font: appearance.navigationTitleFont]
+        navigationController?.navigationBar.titleTextAttributes = [
+            NSAttributedStringKey.font: appearance.navigationTitleFont,
+            NSAttributedStringKey.foregroundColor: appearance.navigationTitleColor
+        ]
         
         let sendBarButtonItem = UIBarButtonItem(title: interfaceText.feedbackSendButtonTitle, style: .done, target: self, action: #selector(FeedbackViewController.sendButtonTapped))
         sendBarButtonItem.setTitleTextAttributesForAllStates([.font: appearance.feedbackSendButtonFont])

--- a/PinpointKit/PinpointKit/Sources/Core/InterfaceCustomization.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/InterfaceCustomization.swift
@@ -38,6 +38,9 @@ public struct InterfaceCustomization {
         
         /// The stroke color for annotations.
         let annotationStrokeColor: UIColor
+
+        /// The font used for navigation titles.
+        let navigationTitleColor: UIColor
         
         /// The font used for navigation titles.
         let navigationTitleFont: UIFont
@@ -76,6 +79,7 @@ public struct InterfaceCustomization {
          - parameter annotationFillColor:                   The fill color for annotations. If none is supplied, the `tintColor` of the relevant view will be used.
          - parameter annotationStrokeColor:                 The stroke color for annotations.
          - parameter annotationTextAttributes:              The text attributes for annotations.
+         - parameter navigationTitleColor:                  The color used for navigation titles.
          - parameter navigationTitleFont:                   The font used for navigation titles.
          - parameter feedbackSendButtonFont:                The font used for the button that sends feedback.
          - parameter feedbackCancelButtonFont:              The font used for the button that cancels feedback collection.
@@ -91,6 +95,7 @@ public struct InterfaceCustomization {
                     annotationFillColor: UIColor? = nil,
                     annotationStrokeColor: UIColor = .white,
                     annotationTextAttributes: [String: AnyObject]? = nil,
+                    navigationTitleColor: UIColor = UIColor.darkText,
                     navigationTitleFont: UIFont = .sourceSansProFont(ofSize: 19, weight: .semibold),
                     feedbackSendButtonFont: UIFont = .sourceSansProFont(ofSize: 19, weight: .semibold),
                     feedbackCancelButtonFont: UIFont = .sourceSansProFont(ofSize: 19),
@@ -104,6 +109,7 @@ public struct InterfaceCustomization {
             self.tintColor = tintColor
             self.annotationFillColor = annotationFillColor
             self.annotationStrokeColor = annotationStrokeColor
+            self.navigationTitleColor = navigationTitleColor
             
             // Custom annotation text attributes
             if var customAnnotationTextAttributes = annotationTextAttributes {

--- a/PinpointKit/PinpointKit/Sources/Core/InterfaceCustomization.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/InterfaceCustomization.swift
@@ -26,6 +26,9 @@ public struct InterfaceCustomization {
      *  A struct containing information about the appearance of displayed components.
      */
     public struct Appearance {
+
+        /// The status bar style of PinpointKit
+        let statusBarStyle: UIStatusBarStyle
         
         /// The tint color of PinpointKit views used to style interactive and selected elements.
         let tintColor: UIColor?
@@ -74,7 +77,8 @@ public struct InterfaceCustomization {
         
         /**
          Initializes an `Appearance` object with a optional annotation color properties.
-         
+
+         - parameter statusBarStyle:                        The status bar style of PinpointKit
          - parameter tintColor:                             The tint color of the interface.
          - parameter annotationFillColor:                   The fill color for annotations. If none is supplied, the `tintColor` of the relevant view will be used.
          - parameter annotationStrokeColor:                 The stroke color for annotations.
@@ -91,7 +95,8 @@ public struct InterfaceCustomization {
          - parameter editorTextAnnotationDismissButtonFont: The font used for the dismiss button in the editor displayed while editing a text annotation.
          - parameter editorDoneButtonFont:                  The font used for the done button in the editor to finish editing the image.
          */
-        public init(tintColor: UIColor? = .pinpointOrange(),
+        public init(statusBarStyle: UIStatusBarStyle = .default,
+                    tintColor: UIColor? = .pinpointOrange(),
                     annotationFillColor: UIColor? = nil,
                     annotationStrokeColor: UIColor = .white,
                     annotationTextAttributes: [String: AnyObject]? = nil,
@@ -106,6 +111,7 @@ public struct InterfaceCustomization {
                     editorTextAnnotationSegmentFont: UIFont = .sourceSansProFont(ofSize: 18),
                     editorTextAnnotationDismissButtonFont: UIFont = .sourceSansProFont(ofSize: 19, weight: .semibold),
                     editorDoneButtonFont: UIFont = .sourceSansProFont(ofSize: 19, weight: .semibold)) {
+            self.statusBarStyle = statusBarStyle
             self.tintColor = tintColor
             self.annotationFillColor = annotationFillColor
             self.annotationStrokeColor = annotationStrokeColor


### PR DESCRIPTION
## What It Does

Allows to customize:

1. Status bar appearance, so it is readable on dark backgrounds
2. The color of the navigation bar title (global `UIAppearance` is overridden by PinpointKit because it sets `titleTextAttributes` 
3. Render glyphs in segmented color as template images to adopt the tint color

This is how it looks in a darker environment:

![](http://share.florianbuerger.com/Simulator-Screen-Shot-iPhone-SE-2018-07-18-at-21.50.38.png)
![](http://share.florianbuerger.com/Simulator-Screen-Shot-iPhone-SE-2018-07-18-at-21.50.41.png)