### PR TITLE
Style Consistency Pass

### DIFF
--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditorDelegate.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditorDelegate.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Lickability. All rights reserved.
 //
 
-/// A delegate for the Editor.
+/// A delegate for the `Editor`.
 public protocol EditorDelegate: class {
     
     /**
@@ -61,7 +61,7 @@ public protocol EditorDelegate: class {
     func editorDidDismiss(_ editor: Editor, with screenshot: UIImage)
 }
 
-/// Extends editor delegate with base implementation for functions.
+/// Extends `EditorDelegate` with base implementation for functions.
 extension EditorDelegate {
     
     public func editor(_editor: Editor, didSelect tool: Tool) {

--- a/PinpointKit/PinpointKit/Sources/Core/FeedbackViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/FeedbackViewController.swift
@@ -121,8 +121,8 @@ public final class FeedbackViewController: UITableViewController {
 
         title = interfaceText.feedbackCollectorTitle
         navigationController?.navigationBar.titleTextAttributes = [
-            NSAttributedStringKey.font: appearance.navigationTitleFont,
-            NSAttributedStringKey.foregroundColor: appearance.navigationTitleColor
+            .font: appearance.navigationTitleFont,
+            .foregroundColor: appearance.navigationTitleColor
         ]
         
         let sendBarButtonItem = UIBarButtonItem(title: interfaceText.feedbackSendButtonTitle, style: .done, target: self, action: #selector(FeedbackViewController.sendButtonTapped))

--- a/PinpointKit/PinpointKit/Sources/Core/InterfaceCustomization.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/InterfaceCustomization.swift
@@ -100,7 +100,7 @@ public struct InterfaceCustomization {
                     annotationFillColor: UIColor? = nil,
                     annotationStrokeColor: UIColor = .white,
                     annotationTextAttributes: [String: AnyObject]? = nil,
-                    navigationTitleColor: UIColor = UIColor.darkText,
+                    navigationTitleColor: UIColor = .darkText,
                     navigationTitleFont: UIFont = .sourceSansProFont(ofSize: 19, weight: .semibold),
                     feedbackSendButtonFont: UIFont = .sourceSansProFont(ofSize: 19, weight: .semibold),
                     feedbackCancelButtonFont: UIFont = .sourceSansProFont(ofSize: 19),

--- a/PinpointKit/PinpointKit/Sources/Core/InterfaceCustomization.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/InterfaceCustomization.swift
@@ -27,7 +27,7 @@ public struct InterfaceCustomization {
      */
     public struct Appearance {
 
-        /// The status bar style of PinpointKit
+        /// The status bar style of PinpointKit.
         let statusBarStyle: UIStatusBarStyle
         
         /// The tint color of PinpointKit views used to style interactive and selected elements.
@@ -78,7 +78,7 @@ public struct InterfaceCustomization {
         /**
          Initializes an `Appearance` object with a optional annotation color properties.
 
-         - parameter statusBarStyle:                        The status bar style of PinpointKit
+         - parameter statusBarStyle:                        The status bar style of PinpointKit.
          - parameter tintColor:                             The tint color of the interface.
          - parameter annotationFillColor:                   The fill color for annotations. If none is supplied, the `tintColor` of the relevant view will be used.
          - parameter annotationStrokeColor:                 The stroke color for annotations.

--- a/PinpointKit/PinpointKit/Sources/Core/NSBundle+PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/NSBundle+PinpointKit.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-/// Extends `NSBundle` to provide bundles from PinpointKit.
+/// Extends `Bundle` to provide bundles from PinpointKit.
 extension Bundle {
     
     /**

--- a/PinpointKit/PinpointKit/Sources/Core/PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/PinpointKit.swift
@@ -135,7 +135,7 @@ public protocol PinpointKitDelegate: class {
     func pinpointKit(_ pinpointKit: PinpointKit, didFailToSend feedback: Feedback, error: Error)
 }
 
-/// An extension on PinpointKitDelegate that makes all delegate methods optional to implement. The `pinpointKit(_:didFailToSend:error)` implementation presents a default alert for the `MailSender.Error.mailCannotSend` error.
+/// An extension on `PinpointKitDelegate` that makes all delegate methods optional to implement. The `pinpointKit(_:didFailToSend:error)` implementation presents a default alert for the `MailSender.Error.mailCannotSend` error.
 public extension PinpointKitDelegate {
     func pinpointKit(_ pinpointKit: PinpointKit, willSend feedback: Feedback) {}
     func pinpointKit(_ pinpointKit: PinpointKit, didSend feedback: Feedback) {}

--- a/PinpointKit/PinpointKit/Sources/Core/Sender.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Sender.swift
@@ -45,7 +45,7 @@ public protocol SenderDelegate: class {
     func sender(_ sender: Sender, didFailToSend feedback: Feedback?, error: Error)
 }
 
-/// An extension on PinpointKitDelegate that makes some of the delegate methods optional by giving them empty implementations by default.
+/// An extension on `PinpointKitDelegate` that makes some of the delegate methods optional by giving them empty implementations by default.
 public extension SenderDelegate {
 
     func sender(_ sender: Sender, didFailToSend feedback: Feedback?, error: Error) { }

--- a/PinpointKit/PinpointKit/Sources/Core/StrokeLayoutManager.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/StrokeLayoutManager.swift
@@ -22,7 +22,7 @@ final class StrokeLayoutManager: NSLayoutManager {
         
         let firstIndex = characterIndexForGlyph(at: glyphsToShow.location)
         let attributes = textStorage?.attributes(at: firstIndex, effectiveRange: nil)
-        let shadow = attributes?[NSAttributedStringKey.shadow] as? NSShadow
+        let shadow = attributes?[.shadow] as? NSShadow
         let shouldRenderTransparencyLayer = strokeColor != nil && strokeWidth != nil && shadow != nil
         
         if let shadow = shadow, shouldRenderTransparencyLayer {
@@ -49,7 +49,7 @@ final class StrokeLayoutManager: NSLayoutManager {
         guard let strokeWidth = self.strokeWidth else { return }
         
         // Remove the shadow. It'll all be drawn at once afterwards.
-        textAttributes[NSAttributedStringKey.shadow] = nil
+        textAttributes[.shadow] = nil
         graphicsContext.setShadow(offset: CGSize.zero, blur: 0, color: nil)
         
         graphicsContext.saveGState()

--- a/PinpointKit/PinpointKit/Sources/Core/TextAnnotationView.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/TextAnnotationView.swift
@@ -108,7 +108,7 @@ open class TextAnnotationView: AnnotationView, UITextViewDelegate {
         let character = "." as NSString
         let textFont = textAttributes[NSAttributedStringKey.font.rawValue] ?? font
         
-        let size = character.boundingRect(with: CGSize(width: width, height: CGFloat.greatestFiniteMagnitude), options: .usesLineFragmentOrigin, attributes: [NSAttributedStringKey.font: textFont], context: nil)
+        let size = character.boundingRect(with: CGSize(width: width, height: CGFloat.greatestFiniteMagnitude), options: .usesLineFragmentOrigin, attributes: [.font: textFont], context: nil)
         return CGSize(width: width, height: size.height + TextAnnotationView.TextViewInset.top + TextAnnotationView.TextViewInset.bottom + TextAnnotationView.TextViewLineFragmentPadding)
     }
     

--- a/PinpointKit/PinpointKit/Sources/Core/UIColor+Palette.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/UIColor+Palette.swift
@@ -8,13 +8,13 @@
 
 import UIKit
 
-/// Extends UIColor to add the PinpointKit-specific colors.
+/// Extends `UIColor` to add the PinpointKit-specific colors.
 public extension UIColor {
     
     /**
      The signature Pinpoint orange color.
      
-     - returns: The Pinpoint specific orange color.
+     - returns: The Pinpoint-specific orange color.
      */
     static func pinpointOrange() -> UIColor {
         return UIColor(red: 1, green: 0.2196, blue: 0.0392, alpha: 1)

--- a/PinpointKit/PinpointKit/Sources/Core/UIGestureRecognizer+FailRecognizing.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/UIGestureRecognizer+FailRecognizing.swift
@@ -8,11 +8,11 @@
 
 import UIKit
 
-/// Extends UIGestureRecognizer to force a failure to recognize the gesture.
+/// Extends `UIGestureRecognizer` to force a failure to recognize the gesture.
 extension UIGestureRecognizer {
     
     /**
-     Function that forces a gesture recognizer to fail
+     Forces the receiver to fail.
      */
     func failRecognizing() {
         if !isEnabled {

--- a/PinpointKit/PinpointKit/Sources/Core/UIView+PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/UIView+PinpointKit.swift
@@ -6,10 +6,10 @@
 //
 //
 
-/// Extends UIView to take a snapshot of the screen.
+/// Extends `UIView` to take a snapshot of the screen.
 extension UIView {
     
-    /// The UIImage representation of this view at the time of access.
+    /// The `UIImage` representation of this view at the time of access.
     var pinpoint_screenshot: UIImage {
         UIGraphicsBeginImageContextWithOptions(bounds.size, true, 0)
         drawHierarchy(in: bounds, afterScreenUpdates: true)


### PR DESCRIPTION
## What It Does

Makes a small style pass covering the following:

* Documentation
    * Docs end in periods.
    * Docs that reference symbols reference the appropriate ones (e.g. `NSBundle` → `Bundle`).
    * Symbols referenced in docs are wrapped in back-ticks.
* Drops `NSAttributedStringKey` and `UIColor` prefixes where type inference makes them unnecessary.

## How to Test

Build and run, and do a quick feature smoke test. Nothing of substance was modified.

## Notes

N/A