### PR TITLE
add swift_version attribute to podspec

### DIFF
--- a/PinpointKit.podspec.json
+++ b/PinpointKit.podspec.json
@@ -22,6 +22,7 @@
   "platforms": {
     "ios": "9.0"
   },
+  "swift_version": "4.2",
   "requires_arc": true,
   "frameworks": [
     "Foundation",


### PR DESCRIPTION
Closes #[255](https://github.com/Lickability/PinpointKit/issues/255)

## What It Does

Defines the version of the Swift compiler used to build the framework.

## How to Test

- `pod install` into an app target, make sure it compiles and has `4.2` as its `SWIFT_VERSION` Xcode target build setting in `Pods.xcodeproj`
- (optional) `pod install` a podspec that declares PinpointKit a dependency