### PR TITLE
Allow HTML body content

### DIFF
--- a/PinpointKit/PinpointKit/Sources/Core/FeedbackConfiguration.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/FeedbackConfiguration.swift
@@ -14,7 +14,7 @@ public struct FeedbackConfiguration {
 		public var content: String
 		public var isHTML: Bool
 
-		init(_ content: String, isHTML: Bool = false) {
+		public init(_ content: String, isHTML: Bool = false) {
 			self.content = content
 			self.isHTML = isHTML
 		}

--- a/PinpointKit/PinpointKit/Sources/Core/FeedbackConfiguration.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/FeedbackConfiguration.swift
@@ -8,6 +8,17 @@
 
 /// Encapsulates configuration properties for all feedback to be sent.
 public struct FeedbackConfiguration {
+
+	/// Encapsulates body content of the feedback submission. Suitable for an email body.
+	public struct Body {
+		public var content: String
+		public var isHTML: Bool
+
+		init(_ content: String, isHTML: Bool = false) {
+			self.content = content
+			self.isHTML = isHTML
+		}
+	}
     
     /// The value of the default parameter for `title` in the initializer.
     public static let DefaultTitle = "Bug Report"
@@ -21,8 +32,8 @@ public struct FeedbackConfiguration {
     /// A short, optional title of the feedback submission. Suitable for an email subject.
     public var title: String?
     
-    /// An optional plain-text body of the feedback submission. Suitable for an email body.
-    public var body: String?
+    /// An optional body of the feedback submission.
+    public var body: Body?
     
     /// A file name without an extension for the logs text file.
     public var logsFileName: String
@@ -47,7 +58,7 @@ public struct FeedbackConfiguration {
     public init(screenshotFileName: String = "Screenshot",
                 recipients: [String],
                 title: String? = FeedbackConfiguration.DefaultTitle,
-                body: String? = nil,
+                body: Body? = nil,
                 logsFileName: String = "logs",
                 additionalInformation: [String: AnyObject]? = nil,
                 presentationStyle: UIModalPresentationStyle = .fullScreen) {

--- a/PinpointKit/PinpointKit/Sources/Core/MailSender.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/MailSender.swift
@@ -102,7 +102,7 @@ private extension MFMailComposeViewController {
         }
         
         if let body = feedback.configuration.body {
-           setMessageBody(body, isHTML: false)
+           setMessageBody(body.content, isHTML: body.isHTML)
         }
         
         try attach(feedback.screenshot, screenshotFileName: feedback.configuration.screenshotFileName)

--- a/PinpointKit/PinpointKit/Sources/Core/PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/PinpointKit.swift
@@ -41,7 +41,7 @@ open class PinpointKit {
      - parameter body:               The default body text of the feedback.
      - parameter delegate:           A delegate that is notified of significant events.
      */
-    public convenience init(feedbackRecipients: [String], title: String? = FeedbackConfiguration.DefaultTitle, body: String? = nil, delegate: PinpointKitDelegate? = nil) {
+    public convenience init(feedbackRecipients: [String], title: String? = FeedbackConfiguration.DefaultTitle, body: FeedbackConfiguration.Body? = nil, delegate: PinpointKitDelegate? = nil) {
         let feedbackConfiguration = FeedbackConfiguration(recipients: feedbackRecipients, title: title, body: body)
         let configuration = Configuration(feedbackConfiguration: feedbackConfiguration)
         


### PR DESCRIPTION
## What It Does

We are using PinpointKit in [Flighty](https://www.flightyapp.com) to send user feedback to [Front](http://frontapp.com). If the image is attached to a plain-text email, it will be shown as an attachment. But if the email is HTML, the image is shown inline which makes understanding reports in Front way easier as you don't have to go back and forth.

If you think this is not something you want to have in PinpointKit, feel free to just close this PR 😄 