### PR TITLE
Fixes Inability to Tap Screenshot on iOS 14

### DIFF
--- a/PinpointKit/PinpointKit/Sources/Core/ScreenshotCell.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/ScreenshotCell.swift
@@ -117,12 +117,12 @@ class ScreenshotCell: UITableViewCell {
         backgroundColor = .clear
         selectionStyle = .none
         
-        addSubview(stackView)
+        contentView.addSubview(stackView)
         
-        stackView.topAnchor.constraint(equalTo: topAnchor).isActive = true
-        stackView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
-        stackView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
-        stackView.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
+        stackView.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
+        stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
+        stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor).isActive = true
+        stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor).isActive = true
         
         stackView.addArrangedSubview(screenshotButton)
         stackView.addArrangedSubview(hintLabel)


### PR DESCRIPTION
Closes #276 

## What It Does

When building / deploying for iOS 14, tapping the screenshot button wasn’t working. This is due to the fact that the contents of the cell were beneath the cell’s content view, which was getting the touch events. This didn’t seem to bite us until iOS 14, but the fix is just to properly add / pin to the cell’s content view. I checked the other cell, `CheckmarkCell` to be certain, and we’re not adding subviews there, so no similar issue exists. 

## How to Test

On iOS 11, 12, 13, 14:
1. Launch the example app.
1. Tap the screenshot.
1. See the editor.

## Notes

N/A