### PR TITLE
Bumps version to 1.5.0

### DIFF
--- a/Example/PinpointKitExample.xcodeproj/project.pbxproj
+++ b/Example/PinpointKitExample.xcodeproj/project.pbxproj
@@ -357,7 +357,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = PinpointKitExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = net.Lickability.PinpointKitExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -370,7 +370,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = PinpointKitExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = net.Lickability.PinpointKitExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - PinpointKit (1.4.0):
-    - PinpointKit/Core (= 1.4.0)
-  - PinpointKit/Core (1.4.0)
+  - PinpointKit (1.5.0):
+    - PinpointKit/Core (= 1.5.0)
+  - PinpointKit/Core (1.5.0)
   - SwiftLint (0.25.1)
 
 DEPENDENCIES:
@@ -17,7 +17,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  PinpointKit: a33c929c2e9c3b7d9a1a343fd309161b71c02d06
+  PinpointKit: a513c4623502581067f3f8b60b9cffef6c8e1025
   SwiftLint: ce933681be10c3266e82576dad676fa815a602e9
 
 PODFILE CHECKSUM: 24af8a2ca63352a72ca1cd13fc8977477eae3a12

--- a/Example/Pods/Local Podspecs/PinpointKit.podspec.json
+++ b/Example/Pods/Local Podspecs/PinpointKit.podspec.json
@@ -1,10 +1,10 @@
 {
   "name": "PinpointKit",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "homepage": "https://github.com/Lickability/PinpointKit",
   "source": {
     "git": "https://github.com/Lickability/PinpointKit.git",
-    "tag": "1.4.0"
+    "tag": "1.5.0"
   },
   "summary": "A library that makes bug reporting simple for your users by allowing them to send feedback with annotated screenshots and logs.",
   "authors": {

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,7 +1,7 @@
 PODS:
-  - PinpointKit (1.4.0):
-    - PinpointKit/Core (= 1.4.0)
-  - PinpointKit/Core (1.4.0)
+  - PinpointKit (1.5.0):
+    - PinpointKit/Core (= 1.5.0)
+  - PinpointKit/Core (1.5.0)
   - SwiftLint (0.25.1)
 
 DEPENDENCIES:
@@ -17,7 +17,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  PinpointKit: a33c929c2e9c3b7d9a1a343fd309161b71c02d06
+  PinpointKit: a513c4623502581067f3f8b60b9cffef6c8e1025
   SwiftLint: ce933681be10c3266e82576dad676fa815a602e9
 
 PODFILE CHECKSUM: 24af8a2ca63352a72ca1cd13fc8977477eae3a12

--- a/Example/Pods/Target Support Files/PinpointKit/Info.plist
+++ b/Example/Pods/Target Support Files/PinpointKit/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>1.4.0</string>
+  <string>1.5.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/PinpointKit.podspec.json
+++ b/PinpointKit.podspec.json
@@ -1,10 +1,10 @@
 {
   "name": "PinpointKit",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "homepage": "https://github.com/Lickability/PinpointKit",
   "source": {
       "git": "https://github.com/Lickability/PinpointKit.git",
-      "tag": "1.4.0"
+      "tag": "1.5.0"
   },
   "summary": "A library that makes bug reporting simple for your users by allowing them to send feedback with annotated screenshots and logs.",
   "authors" : {

--- a/PinpointKit/PinpointKit.xcodeproj/project.pbxproj
+++ b/PinpointKit/PinpointKit.xcodeproj/project.pbxproj
@@ -690,7 +690,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = net.Lickability.PinpointKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -711,7 +711,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = net.Lickability.PinpointKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ platform :ios, '9.0'
 use_frameworks!
 
 target 'YOUR_TARGET_NAME' do
-    pod 'PinpointKit', '~> 1.4.0'
+    pod 'PinpointKit', '~> 1.5.0'
 end
 
 ```
@@ -79,7 +79,7 @@ $ pod install
 We also offer a convenience class, [`ScreenshotDetector`](https://github.com/Lickability/PinpointKit/blob/master/PinpointKit/PinpointKit/Sources/ScreenshotDetector/ScreenshotDetector.swift) that is available via the `ScreenshotDetector` subspec. This class provides delegate callbacks when the user takes a screenshot while using your app. Please see the [Requirements](#requirements) section regarding inclusion of [`ScreenshotDetector`](https://github.com/Lickability/PinpointKit/blob/master/PinpointKit/PinpointKit/Sources/ScreenshotDetector/ScreenshotDetector.swift). You can add this to your project by adding the following line in your `Podfile`, in addition to the one for `PinpointKit` above:
 
 ```ruby
-pod 'PinpointKit/ScreenshotDetector', '~> 1.4.0'
+pod 'PinpointKit/ScreenshotDetector', '~> 1.5.0'
 ```
 
 ### Carthage
@@ -96,7 +96,7 @@ $ brew install carthage
 To integrate PinpointKit into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```ogdl
-github "Lickability/PinpointKit" ~> 1.4.0
+github "Lickability/PinpointKit" ~> 1.5.0
 ```
 
 - Run `carthage update` to build the framework.


### PR DESCRIPTION
## What It Does

Prepares a release for version 1.5.0

## How to Test

Compare to the 1.4.0 version bump PR #274   

## Notes

* Note that a release will not happen immediately after this is merged. All install methods will be tested with these changes before signing off on 1.4.0.