### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ DerivedData
 # Carthage/Checkouts
 
 Carthage/Build
+
+# Swift Package Manager
+.build
+

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,46 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "PinpointKit",
+    platforms: [
+        .iOS(.v9),
+    ],
+    products: [
+        .library(
+            name: "PinpointKit",
+            targets: ["PinpointKit"]
+        ),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "ASLLogger",
+            dependencies: [],
+            path: "PinpointKit/PinpointKit/Sources/ASLLogger",
+            publicHeadersPath: "."
+        ),
+        .target(
+            name: "PinpointKit",
+            dependencies: [
+                "ASLLogger",
+            ],
+            path: "PinpointKit/PinpointKit",
+            exclude: [
+                "Info.plist",
+                "Sources/ASLLogger",
+                "Sources/Core/ASLLogger.h",
+                "Sources/Core/ASLLogger.m",
+                "Sources/Core/SourceSansPro-Semibold.ttf",
+                "Sources/Core/SourceSansPro-Bold.ttf",
+                "Sources/Core/SourceSansPro-Regular.ttf",
+            ],
+            resources: [
+                .copy("Resources/SourceSansPro-Semibold.ttf"),
+                .copy("Resources/SourceSansPro-Regular.ttf"),
+                .copy("Resources/SourceSansPro-Bold.ttf"),
+            ]
+        ),
+    ]
+)

--- a/PinpointKit/PinpointKit/Sources/ASLLogger/ASLLogger.h
+++ b/PinpointKit/PinpointKit/Sources/ASLLogger/ASLLogger.h
@@ -1,0 +1,1 @@
+../Core/ASLLogger.h

--- a/PinpointKit/PinpointKit/Sources/ASLLogger/ASLLogger.m
+++ b/PinpointKit/PinpointKit/Sources/ASLLogger/ASLLogger.m
@@ -1,0 +1,1 @@
+../Core/ASLLogger.m

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/AnnotationViewFactory.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/AnnotationViewFactory.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2016 Lickability. All rights reserved.
 //
 
+import UIKit
+
 /// A factory that constructs `AnnotationView`s.
 struct AnnotationViewFactory {
     

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/Editor.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/Editor.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2016 Lickability. All rights reserved.
 //
 
+import UIKit
+
 /// A protocol describing an object that is responsible for editing a screenshot.
 public protocol Editor: class, InterfaceCustomizable {
     

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditorDelegate.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditorDelegate.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2016 Lickability. All rights reserved.
 //
 
+import UIKit
+
 /// A delegate for the `Editor`.
 public protocol EditorDelegate: class {
     

--- a/PinpointKit/PinpointKit/Sources/Core/FeedbackCollector.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/FeedbackCollector.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2016 Lickability. All rights reserved.
 //
 
+import UIKit
+
 /// A protocol describing an object that can collect feedback about a screenshot.
 public protocol FeedbackCollector: class, LogSupporting, InterfaceCustomizable {
     

--- a/PinpointKit/PinpointKit/Sources/Core/FeedbackConfiguration.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/FeedbackConfiguration.swift
@@ -6,6 +6,8 @@
 //
 //
 
+import UIKit
+
 /// Encapsulates configuration properties for all feedback to be sent.
 public struct FeedbackConfiguration {
     

--- a/PinpointKit/PinpointKit/Sources/Core/InterfaceCustomization.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/InterfaceCustomization.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2016 Lickability. All rights reserved.
 //
 
+import UIKit
+
 /// A struct that supplies customized interface text and appearance values.
 public struct InterfaceCustomization {
     let interfaceText: InterfaceText

--- a/PinpointKit/PinpointKit/Sources/Core/LogViewer.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/LogViewer.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2016 Lickability. All rights reserved.
 //
 
+import UIKit
+
 /// A protocol describing an interface to an object that can view a console log.
 public protocol LogViewer: InterfaceCustomizable {
     

--- a/PinpointKit/PinpointKit/Sources/Core/NSBundle+PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/NSBundle+PinpointKit.swift
@@ -17,6 +17,10 @@ extension Bundle {
      - returns: Returns the bundle associated with PinpointKit.
      */
     static func pinpointKitBundle() -> Bundle {
+        #if SWIFT_PACKAGE
+        return .module
+        #else
         return Bundle(for: PinpointKit.self)
+        #endif
     }
 }

--- a/PinpointKit/PinpointKit/Sources/Core/PinpointKit+ShakePresentation.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/PinpointKit+ShakePresentation.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Lickability. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 /// Extends `PinpointKit` to present itself on the application's root view controller as the result of a shake event.
 extension PinpointKit: ShakeDetectingWindowDelegate {

--- a/PinpointKit/PinpointKit/Sources/Core/PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/PinpointKit.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Lickability. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 /// `PinpointKit` is an object that can be used to collect feedback from application users.
 open class PinpointKit {

--- a/PinpointKit/PinpointKit/Sources/Core/Screenshotter.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Screenshotter.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Lickability. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 /// A class responsible for generating a screenshot image of all windows shown by a `UIApplication` on a given `UIScreen`.
 open class Screenshotter {

--- a/PinpointKit/PinpointKit/Sources/Core/SystemLogCollector.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/SystemLogCollector.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2016 Lickability. All rights reserved.
 //
 
+#if SWIFT_PACKAGE
+import ASLLogger
+#endif
+
 /// A log collector that uses [Apple System Logger](https://developer.apple.com/library/mac/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/LoggingErrorsAndWarnings.html) API to retrieve messages logged to the console with `NSLog`.
 open class SystemLogCollector: LogCollector {
     

--- a/PinpointKit/PinpointKit/Sources/Core/UIView+PinpointKit.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/UIView+PinpointKit.swift
@@ -6,6 +6,8 @@
 //
 //
 
+import UIKit
+
 /// Extends `UIView` to take a snapshot of the screen.
 extension UIView {
     


### PR DESCRIPTION
Closes #264 

## What It Does

This PR adds Swift Package Manager support to this library.

## How to Test

Run the following command in the root directory:

```
swift build -Xswiftc "-sdk" -Xswiftc "`xcrun --sdk iphonesimulator --show-sdk-path`" -Xswiftc "-target" -Xswiftc "x86_64-apple-ios14.0-simulator"
```

Or add this library as a Swift Package to your project.

## Notes

This package contains ASLLogger target (Objective-C) and PinpointKit target (Swift) because SPM doesn't support mixed language target at least now.