### PR TITLE
Fix warnings related to UIMenuController API

### DIFF
--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
@@ -551,7 +551,11 @@ open class EditImageViewController: UIViewController, UIGestureRecognizerDelegat
         previousUpdateAnnotationPanGestureRecognizerLocation = gestureRecognizer.location(in: gestureRecognizer.view)
         currentBlurAnnotationView?.drawsBorder = true
         
-        UIMenuController.shared.setMenuVisible(false, animated: true)
+        if #available(iOS 13.0, *) {
+            UIMenuController.shared.hideMenu()
+        } else {
+            UIMenuController.shared.setMenuVisible(false, animated: true)
+        }
         currentTextAnnotationView?.textView.selectedRange = NSRange()
     }
     
@@ -633,12 +637,19 @@ open class EditImageViewController: UIViewController, UIGestureRecognizerDelegat
         let targetRect = CGRect(origin: point, size: CGSize())
         
         let controller = UIMenuController.shared
-        controller.setTargetRect(targetRect, in: view)
+        if #available(iOS 13.0, *) {
+        } else {
+            controller.setTargetRect(targetRect, in: view)
+        }
         controller.menuItems = [
             UIMenuItem(title: "Delete", action: #selector(EditImageViewController.deleteSelectedAnnotationView))
         ]
         controller.update()
-        controller.setMenuVisible(true, animated: true)
+        if #available(iOS 13.0, *) {
+            controller.showMenu(from: view, rect: targetRect)
+        } else {
+            controller.setMenuVisible(true, animated: true)
+        }
     }
     
     private func deleteAnnotationView(_ annotationView: UIView, animated: Bool) {


### PR DESCRIPTION
Closes N/A

## What It Does

This PR fixes warnings related to UIMenuController API.

- 'setTargetRect(_:in:)' was deprecated in iOS 13.0: Use showMenuFromView:rect: instead.
- 'setMenuVisible(_:animated:)' was deprecated in iOS 13.0: Use showMenuFromView:rect: or hideMenuFromView: instead.

## How to Test

Build in iOS 13+.

## Notes

- https://developer.apple.com/documentation/uikit/uimenucontroller/1622812-settargetrect
- https://developer.apple.com/documentation/uikit/uimenucontroller/1622819-setmenuvisible