### PR TITLE
Added UIWindowScene support

### DIFF
--- a/PinpointKit/PinpointKit/Sources/Core/ShakeDetectingWindow.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/ShakeDetectingWindow.swift
@@ -24,22 +24,24 @@ open class ShakeDetectingWindow: UIWindow {
         self.delegate = delegate
         super.init(frame: frame)
 	}
-
-	// MARK: - UIWindow
-    
-	required public init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-	}	
+	
     /**
      Initializes a `ShakeDetectingWindow`.
 
      - parameter windowScene:The window scene.
      - parameter delegate: An object to notify when a shake motion event occurs.
      */
+    @available(iOS 13.0, *)
     public init(windowScene: UIWindowScene, delegate: ShakeDetectingWindowDelegate) {
         self.delegate = delegate
         super.init(windowScene: windowScene)
     }
+
+	// MARK: - UIWindow
+    
+	required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+	}	
 	
 	// MARK: - UIResponder
     

--- a/PinpointKit/PinpointKit/Sources/Core/ShakeDetectingWindow.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/ShakeDetectingWindow.swift
@@ -29,7 +29,17 @@ open class ShakeDetectingWindow: UIWindow {
     
 	required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-	}
+	}	
+    /**
+     Initializes a `ShakeDetectingWindow`.
+
+     - parameter windowScene:The window scene.
+     - parameter delegate: An object to notify when a shake motion event occurs.
+     */
+    public init(windowScene: UIWindowScene, delegate: ShakeDetectingWindowDelegate) {
+        self.delegate = delegate
+        super.init(windowScene: windowScene)
+    }
 	
 	// MARK: - UIResponder
     


### PR DESCRIPTION
New iOS apps should provide a scene delegate and support multiple windows. 

This change is to support this with ShakeDetectingWindow

Closes #

## What It Does

Adds support to create ShakeDetectingWindow when implementing SceneDelegate.

## How to Test

## Notes
